### PR TITLE
FOLIO-1027 enable lint-raml jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,7 @@ buildMvn {
   publishModDescriptor = 'yes'
   publishAPI = 'yes'
   mvnDeploy = 'yes'
+  runLintRamlCop = 'yes'
 
   doDocker = {
     buildJavaDocker {

--- a/src/main/java/org/folio/rest/impl/LoginAPI.java
+++ b/src/main/java/org/folio/rest/impl/LoginAPI.java
@@ -191,7 +191,7 @@ public class LoginAPI implements AuthnResource {
             } else if(response.statusCode() == 201) {
               JsonObject json = new JsonObject(buf.toString());
               token = json.getString("token");
-            } 
+            }
             if(token == null) {
               future.fail(String.format("Got response %s fetching token, but content is null",
                   response.statusCode()));


### PR DESCRIPTION
Enable lint-raml with CI.

Developers can run the same script locally at `../folio-tools/lint-raml/lint_raml_cop.py`

See the [guides/raml-cop](https://dev.folio.org/guides/raml-cop/).

Also the api.yml configuration has a commented-out entry which is ready for the expected new layout of "ramls" and "ramls/raml-util".