### PR TITLE
MODLOGIN-88: Incorrect error codes returns from BE

### DIFF
--- a/src/main/java/org/folio/rest/impl/LoginAPI.java
+++ b/src/main/java/org/folio/rest/impl/LoginAPI.java
@@ -74,8 +74,8 @@ public class LoginAPI implements Authn {
   private static final String CREDENTIAL_SCHEMA_PATH = "ramls/credentials.json";
   private static final String POSTGRES_ERROR = "Error from PostgresClient ";
   public static final String INTERNAL_ERROR = "Internal Server error";
-  private static final String CODE_USERNAME_INVALID = "username.invalid";
-  public static final String CODE_P_A_S_S_W_O_R_D_INVALID = "wordpass.invalid";
+  private static final String CODE_USERNAME_INCORRECT = "username.incorrect";
+  public static final String CODE_PASSWORD_INCORRECT = "password.incorrect";
   public static final String CODE_FIFTH_FAILED_ATTEMPT_BLOCKED = "fifth.failed.attempt.blocked";
   private static final String CODE_USER_BLOCKED = "user.blocked";
   public static final String CODE_THIRD_FAILED_ATTEMPT = "third.failed.attempt";
@@ -339,7 +339,7 @@ public class LoginAPI implements Authn {
             logger.error(errMsg);
             asyncResultHandler.handle(Future.succeededFuture(
                 PostAuthnLoginResponse.respond422WithApplicationJson(
-                  getErrors(errMsg, CODE_USERNAME_INVALID, new ImmutablePair<>(PARAM_USERNAME, entity.getUsername())))
+                  getErrors(errMsg, CODE_USERNAME_INCORRECT, new ImmutablePair<>(PARAM_USERNAME, entity.getUsername())))
             ));
 
           } else {

--- a/src/main/java/org/folio/util/LoginAttemptsHelper.java
+++ b/src/main/java/org/folio/util/LoginAttemptsHelper.java
@@ -214,7 +214,7 @@ public class LoginAttemptsHelper {
     if (res.failed()) {
       logger.warn(res.cause());
       return Integer.parseInt(MODULE_SPECIFIC_ARGS
-        .getOrDefault(key, "10"));
+        .getOrDefault(key, String.valueOf(defaultValue)));
     } else try {
       return Integer.parseInt(res.result().getString(VALUE));
     } catch (Exception e) {

--- a/src/main/java/org/folio/util/LoginAttemptsHelper.java
+++ b/src/main/java/org/folio/util/LoginAttemptsHelper.java
@@ -195,7 +195,7 @@ public class LoginAttemptsHelper {
             asyncResultHandler.handle(Future.succeededFuture(Authn.PostAuthnLoginResponse.
               respond422WithApplicationJson(
                 LoginAPI.getErrors("Password does not match",
-                  attempts.getAttemptCount().equals(loginFailToWarnValue) ? LoginAPI.CODE_THIRD_FAILED_ATTEMPT : LoginAPI.CODE_P_A_S_S_W_O_R_D_INVALID,
+                  attempts.getAttemptCount().equals(loginFailToWarnValue) ? LoginAPI.CODE_THIRD_FAILED_ATTEMPT : LoginAPI.CODE_PASSWORD_INCORRECT,
                   new ImmutablePair<>(LoginAPI.PARAM_USERNAME, userObject.getString("username"))
               ))));
         }
@@ -391,7 +391,7 @@ public class LoginAttemptsHelper {
 
           asyncResultHandler.handle(Future.succeededFuture(Authn.PostAuthnLoginResponse.
             respond422WithApplicationJson(
-              LoginAPI.getErrors("Password does not match", LoginAPI.CODE_P_A_S_S_W_O_R_D_INVALID,
+              LoginAPI.getErrors("Password does not match", LoginAPI.CODE_PASSWORD_INCORRECT,
                 new ImmutablePair<>(LoginAPI.PARAM_USERNAME, userObject.getString("username"))
               ))));
         } else {


### PR DESCRIPTION
1. Fixed an issue with getting error after three and five failed attempts to login.
2. Fixed error codes, set "username.incorrect" for incorrect username and "password.incorrect" for incorrect password.

Jira ticket: [MODLOGIN-88](https://issues.folio.org/browse/MODLOGIN-88)