### PR TITLE
FOLIO-2003 initial module metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,26 @@ this module may vary (username/password, SAML, OAuth, etc.), and it is possible
 for more than one Authentication module to exist in a running system. The
 default implementation uses a simple username and password for authentication.
 
+# Module properties to set up at mod-configuration
+
+* login.fail.attempts - number of login attempts before block user account (default value - 5)
+* login.fail.timeout - after timeout in minutes, fail login attempts will be dropped (default value - 10)
+
 # Additional information
 
 The [raml-module-builder](https://github.com/folio-org/raml-module-builder) framework.
 
 Other [modules](https://dev.folio.org/source-code/#server-side).
 
+Other FOLIO Developer documentation is at [dev.folio.org](https://dev.folio.org/)
+
+### Issue tracker
+
 See project [MODLOGIN](https://issues.folio.org/browse/MODLOGIN)
 at the [FOLIO issue tracker](https://dev.folio.org/guidelines/issue-tracker).
 
-Other FOLIO Developer documentation is at [dev.folio.org](https://dev.folio.org/)
+### ModuleDescriptor
 
-# Module properties to set up at mod-configuration
-* login.fail.attempts - number of login attempts before block user account (default value - 5)
-* login.fail.timeout - after timeout in minutes, fail login attempts will be dropped (default value - 10)
+See the built `target/ModuleDescriptor.json` for the interfaces that this module
+requires and provides, the permissions, and the additional module metadata.
+

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -208,6 +208,10 @@
       ]
     }
   ],
+  "metadata": {
+    "containerMemory": "256",
+    "databaseConnection": "true"
+  },
   "launchDescriptor": {
     "dockerImage": "${artifactId}:${version}",
     "dockerArgs": {


### PR DESCRIPTION
Declare additional module metadata in ModuleDescriptor: containerMemory, databaseConnection

[FOLIO-2003](https://issues.folio.org/browse/FOLIO-2003)
