### PR TITLE
MODLOGIN-114 Change the implementation of password checking for repeatability [Reset passwords: user can reset password by link]

### DIFF
--- a/ramls/password.json
+++ b/ramls/password.json
@@ -6,9 +6,14 @@
     "password": {
       "type": "string",
       "description": "Password"
+    },
+    "userId": {
+      "type": "string",
+      "description": "User Id"
     }
   },
   "required": [
-    "password"
+    "password",
+    "userId"
   ]
 }

--- a/src/test/java/org/folio/logintest/PasswordRepeatabilityValidationTest.java
+++ b/src/test/java/org/folio/logintest/PasswordRepeatabilityValidationTest.java
@@ -114,13 +114,9 @@ public class PasswordRepeatabilityValidationTest {
 
   @Test
   public void testNewPassword() {
-    Password passwordEntity = new Password()
-      .withPassword(NEW_PASSWORD)
-      .withUserId(USER_ID);
-
     RestAssured.given()
       .spec(spec)
-      .body(passwordEntity)
+      .body(buildPasswordEntity(NEW_PASSWORD))
       .when()
       .post(PASSWORD_REAPITABILITY_VALIDATION_PATH)
       .then()
@@ -130,13 +126,9 @@ public class PasswordRepeatabilityValidationTest {
 
   @Test
   public void testRecentPassword() {
-    Password passwordEntity = new Password()
-      .withPassword(PASSWORD_TEMPLATE + 1)
-      .withUserId(USER_ID);
-
     RestAssured.given()
       .spec(spec)
-      .body(passwordEntity)
+      .body(buildPasswordEntity(PASSWORD_TEMPLATE + 1))
       .when()
       .post(PASSWORD_REAPITABILITY_VALIDATION_PATH)
       .then()
@@ -146,13 +138,9 @@ public class PasswordRepeatabilityValidationTest {
 
   @Test
   public void testOldPassword() {
-    Password passwordEntity = new Password()
-      .withPassword(OLD_PASSWORD)
-      .withUserId(USER_ID);
-
     RestAssured.given()
       .spec(spec)
-      .body(passwordEntity)
+      .body(buildPasswordEntity(OLD_PASSWORD))
       .when()
       .post(PASSWORD_REAPITABILITY_VALIDATION_PATH)
       .then()
@@ -162,14 +150,10 @@ public class PasswordRepeatabilityValidationTest {
 
   @Test
   public void testCurrentPassword() {
-    Password passwordEntity = new Password()
-      .withPassword(CURRENT_PASSWORD)
-      .withUserId(USER_ID);
-
     RestAssured.given()
       .spec(spec)
       .header(RestVerticle.OKAPI_USERID_HEADER, USER_ID)
-      .body(passwordEntity)
+      .body(buildPasswordEntity(CURRENT_PASSWORD))
       .when()
       .post(PASSWORD_REAPITABILITY_VALIDATION_PATH)
       .then()
@@ -245,5 +229,11 @@ public class PasswordRepeatabilityValidationTest {
     history.setDate(date);
 
     return history;
+  }
+
+  private Password buildPasswordEntity(String password) {
+    return new Password()
+      .withPassword(password)
+      .withUserId(USER_ID);
   }
 }

--- a/src/test/java/org/folio/logintest/PasswordRepeatabilityValidationTest.java
+++ b/src/test/java/org/folio/logintest/PasswordRepeatabilityValidationTest.java
@@ -17,6 +17,7 @@ import org.folio.rest.client.TenantClient;
 import org.folio.rest.impl.LoginAPI;
 import org.folio.rest.jaxrs.model.Credential;
 import org.folio.rest.jaxrs.model.CredentialsHistory;
+import org.folio.rest.jaxrs.model.Password;
 import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.tools.utils.NetworkUtils;
@@ -53,17 +54,14 @@ public class PasswordRepeatabilityValidationTest {
   private static final String CURRENT_PASSWORD = "Current!@1";
   private static final int PASSWORDS_HISTORY_NUMBER = 10;
   private static final String RESULT_JSON_PATH = "result";
-  private static final String PASSWORD_JSON_PATH = "password";
   private static final String VALID = "valid";
   private static final String INVALID = "invalid";
-
-  private static int port;
 
   @BeforeClass
   public static void setup(final TestContext context) {
     Async async = context.async();
     vertx = Vertx.vertx();
-    port = NetworkUtils.nextFreePort();
+    int port = NetworkUtils.nextFreePort();
 
     try {
       PostgresClient.setIsEmbedded(true);
@@ -94,7 +92,6 @@ public class PasswordRepeatabilityValidationTest {
       .setBaseUri("http://localhost:" + port)
       .addHeader(RestVerticle.OKAPI_HEADER_TENANT, TENANT)
       .addHeader(RestVerticle.OKAPI_HEADER_TOKEN, "dummytoken")
-      .addHeader(LoginAPI.OKAPI_USER_ID_HEADER, USER_ID)
       .addHeader(LoginAPI.OKAPI_URL_HEADER, "http://localhost:" + port)
       .build();
   }
@@ -117,9 +114,13 @@ public class PasswordRepeatabilityValidationTest {
 
   @Test
   public void testNewPassword() {
+    Password passwordEntity = new Password()
+      .withPassword(NEW_PASSWORD)
+      .withUserId(USER_ID);
+
     RestAssured.given()
       .spec(spec)
-      .body(new JsonObject().put(PASSWORD_JSON_PATH, NEW_PASSWORD).encode())
+      .body(passwordEntity)
       .when()
       .post(PASSWORD_REAPITABILITY_VALIDATION_PATH)
       .then()
@@ -129,9 +130,13 @@ public class PasswordRepeatabilityValidationTest {
 
   @Test
   public void testRecentPassword() {
+    Password passwordEntity = new Password()
+      .withPassword(PASSWORD_TEMPLATE + 1)
+      .withUserId(USER_ID);
+
     RestAssured.given()
       .spec(spec)
-      .body(new JsonObject().put(PASSWORD_JSON_PATH, PASSWORD_TEMPLATE + 1).encode())
+      .body(passwordEntity)
       .when()
       .post(PASSWORD_REAPITABILITY_VALIDATION_PATH)
       .then()
@@ -141,9 +146,13 @@ public class PasswordRepeatabilityValidationTest {
 
   @Test
   public void testOldPassword() {
+    Password passwordEntity = new Password()
+      .withPassword(OLD_PASSWORD)
+      .withUserId(USER_ID);
+
     RestAssured.given()
       .spec(spec)
-      .body(new JsonObject().put(PASSWORD_JSON_PATH, OLD_PASSWORD).encode())
+      .body(passwordEntity)
       .when()
       .post(PASSWORD_REAPITABILITY_VALIDATION_PATH)
       .then()
@@ -153,10 +162,14 @@ public class PasswordRepeatabilityValidationTest {
 
   @Test
   public void testCurrentPassword() {
+    Password passwordEntity = new Password()
+      .withPassword(CURRENT_PASSWORD)
+      .withUserId(USER_ID);
+
     RestAssured.given()
       .spec(spec)
       .header(RestVerticle.OKAPI_USERID_HEADER, USER_ID)
-      .body(new JsonObject().put(PASSWORD_JSON_PATH, CURRENT_PASSWORD).encode())
+      .body(passwordEntity)
       .when()
       .post(PASSWORD_REAPITABILITY_VALIDATION_PATH)
       .then()


### PR DESCRIPTION
**Purpose**
Update `mod-login` API contract to implement a user password reset by link.

Resolves: [MODLOGIN-114](https://issues.folio.org/browse/MODLOGIN-114)