### PR TITLE
Raising the interface version related to mod-login API breaking change

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "login",
-      "version": "5.0",
+      "version": "6.0",
       "handlers" : [
         {
           "methods" : [ "POST" ],

--- a/ramls/login.raml
+++ b/ramls/login.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Login
-version: v1.1
+version: v6.0
 baseUri: http://github.com/org/folio/mod-auth/login_module
 
 documentation:


### PR DESCRIPTION
Changes in the version of the mod-login https://github.com/folio-org/mod-login/pull/64 affect changes in the modules: 

-  'edge-oai-pmh',
-  'edge-orders',
-  'edge-patron',
-  'edge-rtac',
-  'ui-users',
-  'mod-users-bl'
-  'edge-sip2'
-  'mod-login'