### PR TITLE
MODLOGIN-116: reduce HttpClient creation to one time

### DIFF
--- a/src/main/java/org/folio/rest/impl/InitAPIs.java
+++ b/src/main/java/org/folio/rest/impl/InitAPIs.java
@@ -5,6 +5,7 @@ import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClientOptions;
 import io.vertx.serviceproxy.ServiceBinder;
 import org.folio.rest.resource.interfaces.InitAPI;
 import org.folio.services.ConfigurationService;
@@ -14,6 +15,7 @@ import org.folio.services.PasswordStorageService;
 import java.net.URL;
 import java.util.MissingResourceException;
 
+import static org.folio.rest.RestVerticle.MODULE_SPECIFIC_ARGS;
 import static org.folio.util.LoginConfigUtils.*;
 
 /**
@@ -26,6 +28,10 @@ public class InitAPIs implements InitAPI {
   private static final String CREDENTIAL_SCHEMA_PATH = "ramls/credentials.json";
 
   public void init(Vertx vertx, Context context, Handler<AsyncResult<Boolean>> resultHandler) {
+    final int timeout = Integer.parseInt(MODULE_SPECIFIC_ARGS.getOrDefault("lookup.timeout", "1000"));
+    context.put("httpClient", vertx.createHttpClient(new HttpClientOptions()
+        .setConnectTimeout(timeout)
+        .setIdleTimeout(timeout)));
     URL u = InitAPIs.class.getClassLoader().getResource(CREDENTIAL_SCHEMA_PATH);
     if (u == null) {
       resultHandler.handle(Future.failedFuture(new MissingResourceException(CREDENTIAL_SCHEMA_PATH, InitAPIs.class.getName(), CREDENTIAL_SCHEMA_PATH)));

--- a/src/main/java/org/folio/rest/impl/InitAPIs.java
+++ b/src/main/java/org/folio/rest/impl/InitAPIs.java
@@ -16,6 +16,8 @@ import java.net.URL;
 import java.util.MissingResourceException;
 
 import static org.folio.rest.RestVerticle.MODULE_SPECIFIC_ARGS;
+import static org.folio.util.Constants.DEFAULT_TIMEOUT;
+import static org.folio.util.Constants.LOOKUP_TIMEOUT;
 import static org.folio.util.LoginConfigUtils.*;
 
 /**
@@ -28,7 +30,7 @@ public class InitAPIs implements InitAPI {
   private static final String CREDENTIAL_SCHEMA_PATH = "ramls/credentials.json";
 
   public void init(Vertx vertx, Context context, Handler<AsyncResult<Boolean>> resultHandler) {
-    final int timeout = Integer.parseInt(MODULE_SPECIFIC_ARGS.getOrDefault("lookup.timeout", "1000"));
+    final int timeout = Integer.parseInt(MODULE_SPECIFIC_ARGS.getOrDefault(LOOKUP_TIMEOUT, DEFAULT_TIMEOUT));
     context.put("httpClient", vertx.createHttpClient(new HttpClientOptions()
         .setConnectTimeout(timeout)
         .setIdleTimeout(timeout)));

--- a/src/main/java/org/folio/rest/impl/LoginAPI.java
+++ b/src/main/java/org/folio/rest/impl/LoginAPI.java
@@ -66,6 +66,9 @@ import java.util.UUID;
 import static javax.ws.rs.core.HttpHeaders.ACCEPT;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static org.folio.rest.RestVerticle.MODULE_SPECIFIC_ARGS;
+import static org.folio.util.Constants.DEFAULT_TIMEOUT;
+import static org.folio.util.Constants.HTTP_CLIENT;
+import static org.folio.util.Constants.LOOKUP_TIMEOUT;
 import static org.folio.util.LoginAttemptsHelper.TABLE_NAME_LOGIN_ATTEMPTS;
 import static org.folio.util.LoginAttemptsHelper.buildCriteriaForUserAttempts;
 import static org.folio.util.LoginConfigUtils.EVENT_CONFIG_PROXY_CONFIG_ADDRESS;
@@ -80,7 +83,6 @@ import static org.folio.util.LoginConfigUtils.getResponseEntity;
  */
 public class LoginAPI implements Authn {
 
-  private static final String HTTP_CLIENT = "httpClient";
   private static final String TABLE_NAME_CREDENTIALS = "auth_credentials";
   public static final String OKAPI_TENANT_HEADER = "x-okapi-tenant";
   public static final String OKAPI_TOKEN_HEADER = "x-okapi-token";
@@ -116,7 +118,7 @@ public class LoginAPI implements Authn {
   private boolean requireActiveUser = Boolean.parseBoolean(MODULE_SPECIFIC_ARGS
       .getOrDefault("require.active", "true"));
   private int lookupTimeout = Integer.parseInt(MODULE_SPECIFIC_ARGS
-      .getOrDefault("lookup.timeout", "1000"));
+      .getOrDefault(LOOKUP_TIMEOUT, DEFAULT_TIMEOUT));
 
   private final Logger logger = LoggerFactory.getLogger(LoginAPI.class);
 

--- a/src/main/java/org/folio/services/impl/ConfigurationServiceImpl.java
+++ b/src/main/java/org/folio/services/impl/ConfigurationServiceImpl.java
@@ -23,6 +23,8 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static org.folio.rest.RestVerticle.*;
+import static org.folio.util.Constants.DEFAULT_TIMEOUT;
+import static org.folio.util.Constants.LOOKUP_TIMEOUT;
 import static org.folio.util.LoginConfigUtils.EVENT_LOG_API_CODE_STATUS;
 import static org.folio.util.LoginConfigUtils.EVENT_LOG_API_MODULE;
 
@@ -33,8 +35,6 @@ public class ConfigurationServiceImpl implements ConfigurationService {
   private static final String REQUEST_URL_TEMPLATE = "%s/%s?query=module==%s";
   private static final String HTTP_HEADER_CONTENT_TYPE = HttpHeaders.CONTENT_TYPE.toString();
   private static final String HTTP_HEADER_ACCEPT = HttpHeaders.ACCEPT.toString();
-  private static final String LOOKUP_TIMEOUT = "lookup.timeout";
-  private static final String LOOKUP_TIMEOUT_VAL = "1000";
   private static final String EVENT_LOG_STATUS_CODE = "statusCode";
 
   private static final Predicate<Config> HAS_EVENT_CONFIG_ENABLE_LOG_CONFIG = config -> config.getModule().equals(EVENT_LOG_API_MODULE) && config.getCode().equals(EVENT_LOG_API_CODE_STATUS);
@@ -50,7 +50,7 @@ public class ConfigurationServiceImpl implements ConfigurationService {
   /**
    * Timeout to wait for response
    */
-  private int lookupTimeout = Integer.parseInt(MODULE_SPECIFIC_ARGS.getOrDefault(LOOKUP_TIMEOUT, LOOKUP_TIMEOUT_VAL));
+  private int lookupTimeout = Integer.parseInt(MODULE_SPECIFIC_ARGS.getOrDefault(LOOKUP_TIMEOUT, DEFAULT_TIMEOUT));
 
   public ConfigurationServiceImpl(Vertx vertx) {
     this.vertx = vertx;

--- a/src/main/java/org/folio/services/impl/PasswordStorageServiceImpl.java
+++ b/src/main/java/org/folio/services/impl/PasswordStorageServiceImpl.java
@@ -69,9 +69,11 @@ public class PasswordStorageServiceImpl implements PasswordStorageService {
   private final Vertx vertx;
   private AuthUtil authUtil = new AuthUtil();
   private LogStorageService logStorageService;
+  private final HttpClient httpClient;
 
   public PasswordStorageServiceImpl(Vertx vertx) {
     this.vertx = vertx;
+    httpClient = vertx.createHttpClient();
     logStorageService = LogStorageService.createProxy(vertx, EVENT_CONFIG_PROXY_STORY_ADDRESS);
   }
 
@@ -581,7 +583,6 @@ public class PasswordStorageServiceImpl implements PasswordStorageService {
 
   private Future<Integer> getPasswordHistoryNumber(String okapiUrl, String token, String tenant) {
     Future<Integer> future = Future.future();
-    HttpClient httpClient = vertx.createHttpClient();
 
     httpClient.getAbs(okapiUrl + PW_HISTORY_NUMBER_CONF_PATH)
       .putHeader(HttpHeaders.ACCEPT, MediaType.TEXT_PLAIN)

--- a/src/main/java/org/folio/util/Constants.java
+++ b/src/main/java/org/folio/util/Constants.java
@@ -1,0 +1,11 @@
+package org.folio.util;
+
+public final class Constants {
+  public static final String HTTP_CLIENT = "httpClient";
+  public static final String LOOKUP_TIMEOUT = "lookup.timeout";
+  public static final String DEFAULT_TIMEOUT = "1000";
+
+  private Constants() {
+    super();
+  }
+}

--- a/src/main/java/org/folio/util/LoginAttemptsHelper.java
+++ b/src/main/java/org/folio/util/LoginAttemptsHelper.java
@@ -32,6 +32,7 @@ import static org.folio.rest.RestVerticle.MODULE_SPECIFIC_ARGS;
 import static org.folio.rest.impl.LoginAPI.CODE_FIFTH_FAILED_ATTEMPT_BLOCKED;
 import static org.folio.rest.impl.LoginAPI.OKAPI_TENANT_HEADER;
 import static org.folio.rest.impl.LoginAPI.OKAPI_TOKEN_HEADER;
+import static org.folio.util.Constants.HTTP_CLIENT;
 import static org.folio.util.LoginConfigUtils.EVENT_CONFIG_PROXY_STORY_ADDRESS;
 
 /**
@@ -55,7 +56,7 @@ public class LoginAttemptsHelper {
   public LoginAttemptsHelper(Vertx vertx) {
     this.vertx = vertx;
     logStorageService = LogStorageService.createProxy(vertx, EVENT_CONFIG_PROXY_STORY_ADDRESS);
-    this.httpClient = vertx.getOrCreateContext().get("httpClient");
+    this.httpClient = vertx.getOrCreateContext().get(HTTP_CLIENT);
   }
 
   /**

--- a/src/main/java/org/folio/util/LoginAttemptsHelper.java
+++ b/src/main/java/org/folio/util/LoginAttemptsHelper.java
@@ -55,7 +55,7 @@ public class LoginAttemptsHelper {
   public LoginAttemptsHelper(Vertx vertx) {
     this.vertx = vertx;
     logStorageService = LogStorageService.createProxy(vertx, EVENT_CONFIG_PROXY_STORY_ADDRESS);
-    httpClient = vertx.createHttpClient();
+    this.httpClient = vertx.getOrCreateContext().get("httpClient");
   }
 
   /**


### PR DESCRIPTION
Moved the login API's `HttpClient` creation to `InitAPIs`. The client is stored in the vertx context shared by the APIs. A static `HttpClient` singleton would not work well for testing without modifying the security model to reset the static. Cleaning up the client seemed challenging without refactoring much of the code.

A couple things worth noting:
1. I moved the `lookup.timeout` `HttpClientOptions` as well. However, I see we are using the same value for both the connect timeout and the idle timeout. The value itself defaults to `1000` which would suggest milliseconds and the connect timeout is in ms, however, the idle timeout unit defaults to seconds. This may not be the intended usage here and should probably be looked into at some point.
1. Also, at some point, `ConfigurationServiceImpl` and `PasswordStorageServiceImpl` should be profiled to see if they are leaking `HttpClient` objects (it looks like they would). But, they use the `EventBus`, so it is not entirely clear.