### PR TITLE
publish container to ci kubernetes when snap/release build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,7 @@ buildMvn {
   publishAPI = 'yes'
   mvnDeploy = 'yes'
   runLintRamlCop = 'yes'
+  doKubeDeploy = true
 
   doDocker = {
     buildJavaDocker {


### PR DESCRIPTION
Enables kubeDeploy step on buildMvn pipeline to deploy container to CI kubernetes cluster on release/snapshot builds for FOLIO-2256.
