### PR TITLE
MODLOGIN-24 add validation for missed password

### DIFF
--- a/src/main/java/org/folio/rest/impl/LoginAPI.java
+++ b/src/main/java/org/folio/rest/impl/LoginAPI.java
@@ -1305,25 +1305,35 @@ public class LoginAPI implements Authn {
     return cred;
   }
 
-  public static Errors getErrors(String errorMessage, String errorCode, Pair... pairs) {
+  public static Errors getErrors(String errorMessage, String errorCode,
+    Pair<String, String> pair) {
+
     Errors errors = new Errors();
-    Error error = new Error();
-    error.setMessage(errorMessage);
-    error.setCode(errorCode);
-    error.setType(TYPE_ERROR);
+    Error error = getError(errorMessage, errorCode);
     List<Parameter> params = new ArrayList<>();
-    if (pairs.length > 0) {
-      for (Pair p : pairs) {
-        if (p.getKey() != null && p.getValue() != null) {
-          Parameter param = new Parameter();
-          param.setKey((String) p.getKey());
-          param.setValue((String) p.getValue());
-          params.add(param);
-        }
-      }
+    if (pair.getKey() != null && pair.getValue() != null) {
+      Parameter param = new Parameter();
+      param.setKey(pair.getKey());
+      param.setValue(pair.getValue());
+      params.add(param);
     }
     error.withParameters(params);
     errors.setErrors(Collections.singletonList(error));
     return errors;
+  }
+
+  public static Errors getErrors(String errorMessage, String errorCode) {
+    Errors errors = new Errors();
+    Error error = getError(errorMessage, errorCode);
+    errors.setErrors(Collections.singletonList(error));
+    return errors;
+  }
+
+  private static Error getError(String errorMessage, String errorCode) {
+    Error error = new Error();
+    error.setMessage(errorMessage);
+    error.setCode(errorCode);
+    error.setType(TYPE_ERROR);
+    return error;
   }
 }

--- a/src/main/java/org/folio/rest/impl/LoginAPI.java
+++ b/src/main/java/org/folio/rest/impl/LoginAPI.java
@@ -608,6 +608,13 @@ public class LoginAPI implements Authn {
           userVerifyFuture = lookupUser(entity.getUsername(), null,
             tenantId, okapiURL, requestToken, vertxContext.owner());
         }
+        if (entity.getPassword() == null) {
+          asyncResultHandler.handle(Future.succeededFuture(
+            PostAuthnCredentialsResponse.respond422WithApplicationJson(
+              ValidationHelper.createValidationErrorMessage(
+                CREDENTIAL_USERID_FIELD, entity.getUserId(), "Password is missing"))));
+          return;
+        }
         userVerifyFuture.setHandler(verifyRes -> {
           if(verifyRes.failed()) {
             String message = "Error looking up user: " + verifyRes.cause()

--- a/src/test/java/org/folio/logintest/LoginAttemptsTest.java
+++ b/src/test/java/org/folio/logintest/LoginAttemptsTest.java
@@ -13,6 +13,7 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.folio.rest.RestVerticle;
 import org.folio.rest.client.TenantClient;
 import org.folio.rest.impl.LoginAPI;
+import org.folio.rest.jaxrs.model.Password;
 import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.tools.utils.NetworkUtils;
@@ -24,6 +25,8 @@ import org.junit.runner.RunWith;
 
 import java.io.UnsupportedEncodingException;
 import java.util.Date;
+import java.util.UUID;
+
 import org.folio.rest.jaxrs.model.TenantAttributes;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -305,5 +308,18 @@ public class LoginAttemptsTest {
       .log().all()
       .statusCode(200)
       .body("attemptCount", is(0));
+  }
+
+  @Test
+  public void shouldReturnValidationErrorWithNoPassword() {
+    RestAssured.given()
+      .spec(spec)
+      .header(RestVerticle.OKAPI_USERID_HEADER, adminId)
+      .body(new Password().withUserId(UUID.randomUUID().toString()))
+      .when()
+      .post(CRED_PATH)
+      .then()
+      .statusCode(422)
+      .body("errors[0].message", equalTo("Password is missing"));
   }
 }


### PR DESCRIPTION
## Purpose 
If /authn/credentials POST API is called with JSON that contains a valid "username" or "userId" for a user that does not have credentials, but the JSON does not contain a "password" field, the API returns 500.
Implement validation that will prevent NullPointerException in mod-login in AuthUti.calculateHash().
422 error should be returned with an error message.

Resolves [MODLOGIN-24](https://issues.folio.org/browse/MODLOGIN-24)