### PR TITLE
MODLOGIN-127 Upgrade to RMB 30.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <ramlfiles_util_path>${basedir}/ramls/raml-util</ramlfiles_util_path>
-    <vertx.version>3.9.0</vertx.version>
+    <vertx.version>3.9.1</vertx.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <ramlfiles_util_path>${basedir}/ramls/raml-util</ramlfiles_util_path>
-    <vertx.version>3.8.4</vertx.version>
+    <vertx.version>3.9.0</vertx.version>
   </properties>
 
   <dependencies>
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>domain-models-runtime</artifactId>
-      <version>29.1.1</version>
+      <version>30.0.0</version>
     </dependency>
 
     <dependency>
@@ -49,6 +49,12 @@
       <version>${vertx.version}</version>
       <scope>test</scope>
       <type>jar</type>
+    </dependency>
+
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web-client</artifactId>
+      <version>${vertx.version}</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/folio/rest/impl/InitAPIs.java
+++ b/src/main/java/org/folio/rest/impl/InitAPIs.java
@@ -1,24 +1,23 @@
 package org.folio.rest.impl;
 
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Context;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
-import io.vertx.core.http.HttpClientOptions;
-import io.vertx.serviceproxy.ServiceBinder;
+import static org.folio.util.LoginConfigUtils.EVENT_CONFIG_PROXY_CONFIG_ADDRESS;
+import static org.folio.util.LoginConfigUtils.EVENT_CONFIG_PROXY_STORY_ADDRESS;
+import static org.folio.util.LoginConfigUtils.PW_CONFIG_PROXY_STORY_ADDRESS;
+
+import java.net.URL;
+import java.util.MissingResourceException;
+
 import org.folio.rest.resource.interfaces.InitAPI;
 import org.folio.services.ConfigurationService;
 import org.folio.services.LogStorageService;
 import org.folio.services.PasswordStorageService;
 
-import java.net.URL;
-import java.util.MissingResourceException;
-
-import static org.folio.rest.RestVerticle.MODULE_SPECIFIC_ARGS;
-import static org.folio.util.Constants.DEFAULT_TIMEOUT;
-import static org.folio.util.Constants.LOOKUP_TIMEOUT;
-import static org.folio.util.LoginConfigUtils.*;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.serviceproxy.ServiceBinder;
 
 /**
  * Performs preprocessing operations before the verticle is deployed,
@@ -30,10 +29,6 @@ public class InitAPIs implements InitAPI {
   private static final String CREDENTIAL_SCHEMA_PATH = "ramls/credentials.json";
 
   public void init(Vertx vertx, Context context, Handler<AsyncResult<Boolean>> resultHandler) {
-    final int timeout = Integer.parseInt(MODULE_SPECIFIC_ARGS.getOrDefault(LOOKUP_TIMEOUT, DEFAULT_TIMEOUT));
-    context.put("httpClient", vertx.createHttpClient(new HttpClientOptions()
-        .setConnectTimeout(timeout)
-        .setIdleTimeout(timeout)));
     URL u = InitAPIs.class.getClassLoader().getResource(CREDENTIAL_SCHEMA_PATH);
     if (u == null) {
       resultHandler.handle(Future.failedFuture(new MissingResourceException(CREDENTIAL_SCHEMA_PATH, InitAPIs.class.getName(), CREDENTIAL_SCHEMA_PATH)));

--- a/src/main/java/org/folio/rest/impl/InitAPIs.java
+++ b/src/main/java/org/folio/rest/impl/InitAPIs.java
@@ -11,6 +11,7 @@ import org.folio.rest.resource.interfaces.InitAPI;
 import org.folio.services.ConfigurationService;
 import org.folio.services.LogStorageService;
 import org.folio.services.PasswordStorageService;
+import org.folio.util.WebClientFactory;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
@@ -29,6 +30,7 @@ public class InitAPIs implements InitAPI {
   private static final String CREDENTIAL_SCHEMA_PATH = "ramls/credentials.json";
 
   public void init(Vertx vertx, Context context, Handler<AsyncResult<Boolean>> resultHandler) {
+    WebClientFactory.init(vertx);
     URL u = InitAPIs.class.getClassLoader().getResource(CREDENTIAL_SCHEMA_PATH);
     if (u == null) {
       resultHandler.handle(Future.failedFuture(new MissingResourceException(CREDENTIAL_SCHEMA_PATH, InitAPIs.class.getName(), CREDENTIAL_SCHEMA_PATH)));

--- a/src/main/java/org/folio/rest/impl/LoginAPI.java
+++ b/src/main/java/org/folio/rest/impl/LoginAPI.java
@@ -126,7 +126,10 @@ public class LoginAPI implements Authn {
   private PasswordStorageService passwordStorageService;
   private LoginAttemptsHelper loginAttemptsHelper;
 
+  private Vertx vertx;
+
   public LoginAPI(Vertx vertx, String tenantId) {
+    this.vertx = vertx;
     this.vTenantId = tenantId;
     initService(vertx);
   }
@@ -201,7 +204,7 @@ public class LoginAPI implements Authn {
 
     requestURL = buildUserLookupURL(okapiURL, username, userId);
     final String finalRequestURL = requestURL;
-    HttpRequest<Buffer> request = WebClientFactory.getWebClient().getAbs(finalRequestURL);
+    HttpRequest<Buffer> request = WebClientFactory.getWebClient(vertx).getAbs(finalRequestURL);
     request.putHeader(OKAPI_TENANT_HEADER, tenant)
       .putHeader(OKAPI_TOKEN_HEADER, requestToken)
       .putHeader(CONTENT_TYPE, APPLICATION_JSON_CONTENT_TYPE)
@@ -226,7 +229,7 @@ public class LoginAPI implements Authn {
   private Future<String> fetchToken(JsonObject payload, String tenant,
       String okapiURL, String requestToken) {
     Promise<String> promise = Promise.promise();
-    HttpRequest<Buffer> request = WebClientFactory.getWebClient().postAbs(okapiURL + "/token");
+    HttpRequest<Buffer> request = WebClientFactory.getWebClient(vertx).postAbs(okapiURL + "/token");
 
     request.putHeader(OKAPI_TENANT_HEADER, tenant)
       .putHeader(OKAPI_TOKEN_HEADER, requestToken)
@@ -267,7 +270,7 @@ public class LoginAPI implements Authn {
   private Future<String> fetchRefreshToken(String userId, String sub, String tenant,
       String okapiURL, String requestToken) {
     Promise<String> promise = Promise.promise();
-    HttpRequest<Buffer> request = WebClientFactory.getWebClient().postAbs(okapiURL + "/refreshtoken");
+    HttpRequest<Buffer> request = WebClientFactory.getWebClient(vertx).postAbs(okapiURL + "/refreshtoken");
     request.putHeader(OKAPI_TENANT_HEADER, tenant)
       .putHeader(OKAPI_TOKEN_HEADER, requestToken)
       .putHeader(CONTENT_TYPE, APPLICATION_JSON_CONTENT_TYPE)

--- a/src/main/java/org/folio/rest/impl/LoginAPI.java
+++ b/src/main/java/org/folio/rest/impl/LoginAPI.java
@@ -197,21 +197,10 @@ public class LoginAPI implements Authn {
   private Future<JsonObject> lookupUser(String username, String userId, String tenant,
       final String okapiURL, String requestToken) {
     Promise<JsonObject> promise = Promise.promise();
-    String requestURL;
-    if(requestToken == null) {
-      requestToken = "";
-    }
-    if(username == null && userId == null) {
-      return Future.failedFuture("Need a valid username or userId to query");
-    }
+    String requestURL = null;
+
     try {
       requestURL = buildUserLookupURL(okapiURL, username, userId);
-    } catch(Exception e) {
-      logger.error("Error building request URL: " + e.getLocalizedMessage());
-      promise.fail(e);
-      return promise.future();
-    }
-    try {
       final String finalRequestURL = requestURL;
       HttpRequest<Buffer> request = WebClientFactory.getWebClient().getAbs(finalRequestURL);
       request.putHeader(OKAPI_TENANT_HEADER, tenant)

--- a/src/main/java/org/folio/rest/impl/LoginAPI.java
+++ b/src/main/java/org/folio/rest/impl/LoginAPI.java
@@ -12,8 +12,6 @@ import static org.folio.util.LoginConfigUtils.VALUE_IS_NOT_FOUND;
 import static org.folio.util.LoginConfigUtils.createFutureResponse;
 import static org.folio.util.LoginConfigUtils.getResponseEntity;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -63,6 +61,7 @@ import org.folio.services.LogStorageService;
 import org.folio.services.PasswordStorageService;
 import org.folio.util.AuthUtil;
 import org.folio.util.LoginAttemptsHelper;
+import org.folio.util.StringUtil;
 import org.folio.util.WebClientFactory;
 
 import io.vertx.core.AsyncResult;
@@ -158,18 +157,15 @@ public class LoginAPI implements Authn {
   }
 
   private String buildUserLookupURL(String okapiURL, String username, String userId) {
-    String requestURL = null;
-    try {
-      if(username != null) {
-        requestURL = String.format("%s/users?query=username==%s", okapiURL,
-            URLEncoder.encode(username, "UTF-8"));
-      } else {
-        requestURL = String.format("%s/users?query=id==%s", okapiURL,
-            URLEncoder.encode(userId, "UTF-8"));
-      }
-    } catch (UnsupportedEncodingException e) {
-      // Should never happen - UTF-8 is supported
+    String requestURL;
+    if(username != null) {
+      requestURL = String.format("%s/users?query=username==%s", okapiURL,
+          StringUtil.urlEncode(username));
+    } else {
+      requestURL = String.format("%s/users?query=id==%s", okapiURL,
+          StringUtil.urlEncode(userId));
     }
+
     return requestURL;
   }
 

--- a/src/main/java/org/folio/rest/impl/LoginAPI.java
+++ b/src/main/java/org/folio/rest/impl/LoginAPI.java
@@ -177,20 +177,19 @@ public class LoginAPI implements Authn {
       String message = "Error looking up user at url '" + requestURL + "' Expected status code 200, got '" + res.statusCode()
           + "' :" + res.bodyAsString();
       throw new UserLookupException(message);
-    } else {
-      JsonObject lookupResult = res.bodyAsJsonObject();
-      if (!lookupResult.containsKey("totalRecords") || !lookupResult.containsKey("users")) {
-        throw new UserLookupException("Error, missing field(s) 'totalRecords' and/or 'users' in user response object");
-      } else {
-        int recordCount = lookupResult.getInteger("totalRecords");
-        if (recordCount > 1) {
-          throw new UserLookupException("Bad results from username");
-        } else if (recordCount == 0) {
-          throw new UserLookupException("No user found by username " + username);
-        }
-      }
-      return lookupResult.getJsonArray("users").getJsonObject(0);
     }
+    JsonObject lookupResult = res.bodyAsJsonObject();
+    if (!lookupResult.containsKey("totalRecords") || !lookupResult.containsKey("users")) {
+      throw new UserLookupException("Error, missing field(s) 'totalRecords' and/or 'users' in user response object");
+    }
+    int recordCount = lookupResult.getInteger("totalRecords");
+    if (recordCount > 1) {
+      throw new UserLookupException("Bad results from username");
+    }
+    if (recordCount == 0) {
+      throw new UserLookupException("No user found by username " + username);
+    }
+    return lookupResult.getJsonArray("users").getJsonObject(0);
   }
 
   /*

--- a/src/main/java/org/folio/services/impl/ConfigurationServiceImpl.java
+++ b/src/main/java/org/folio/services/impl/ConfigurationServiceImpl.java
@@ -48,7 +48,10 @@ public class ConfigurationServiceImpl implements ConfigurationService {
 
   private final Logger logger = LoggerFactory.getLogger(ConfigurationServiceImpl.class);
 
+  private Vertx vertx;
+
   public ConfigurationServiceImpl(Vertx vertx) {
+    this.vertx = vertx;
   }
 
   @Override
@@ -106,7 +109,7 @@ public class ConfigurationServiceImpl implements ConfigurationService {
     String okapiToken = headers.getString(OKAPI_HEADER_TOKEN);
     String requestUrl = String.format(REQUEST_URL_TEMPLATE, okapiUrl, REQUEST_URI_PATH, EVENT_LOG_API_MODULE);
 
-    HttpRequest<Buffer> request = WebClientFactory.getWebClient().getAbs(requestUrl);
+    HttpRequest<Buffer> request = WebClientFactory.getWebClient(vertx).getAbs(requestUrl);
     request.putHeader(OKAPI_HEADER_TOKEN, okapiToken)
       .putHeader(OKAPI_HEADER_TENANT, tenantId)
       .putHeader(HTTP_HEADER_CONTENT_TYPE, MediaType.APPLICATION_JSON)

--- a/src/main/java/org/folio/services/impl/ConfigurationServiceImpl.java
+++ b/src/main/java/org/folio/services/impl/ConfigurationServiceImpl.java
@@ -1,10 +1,7 @@
 package org.folio.services.impl;
 
-import static org.folio.rest.RestVerticle.MODULE_SPECIFIC_ARGS;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TOKEN;
-import static org.folio.util.Constants.DEFAULT_TIMEOUT;
-import static org.folio.util.Constants.LOOKUP_TIMEOUT;
 import static org.folio.util.LoginConfigUtils.EVENT_LOG_API_CODE_STATUS;
 import static org.folio.util.LoginConfigUtils.EVENT_LOG_API_MODULE;
 
@@ -18,6 +15,7 @@ import org.folio.rest.jaxrs.model.Config;
 import org.folio.rest.jaxrs.model.ConfigResponse;
 import org.folio.rest.jaxrs.model.Configurations;
 import org.folio.services.ConfigurationService;
+import org.folio.util.WebClientFactory;
 
 import com.google.common.collect.Lists;
 
@@ -33,8 +31,6 @@ import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.HttpResponse;
-import io.vertx.ext.web.client.WebClient;
-import io.vertx.ext.web.client.WebClientOptions;
 
 public class ConfigurationServiceImpl implements ConfigurationService {
 
@@ -52,21 +48,7 @@ public class ConfigurationServiceImpl implements ConfigurationService {
 
   private final Logger logger = LoggerFactory.getLogger(ConfigurationServiceImpl.class);
 
-  private WebClient httpClient;
-  private final Vertx vertx;
-
-  /**
-   * Timeout to wait for response
-   */
-  private int lookupTimeout = Integer.parseInt(MODULE_SPECIFIC_ARGS.getOrDefault(LOOKUP_TIMEOUT, DEFAULT_TIMEOUT));
-
   public ConfigurationServiceImpl(Vertx vertx) {
-    this.vertx = vertx;
-
-    WebClientOptions options = new WebClientOptions();
-    options.setConnectTimeout(lookupTimeout);
-    options.setIdleTimeout(lookupTimeout);
-    this.httpClient = WebClient.create(vertx, options);
   }
 
   @Override
@@ -123,7 +105,8 @@ public class ConfigurationServiceImpl implements ConfigurationService {
     String okapiUrl = headers.getString(OKAPI_URL_HEADER);
     String okapiToken = headers.getString(OKAPI_HEADER_TOKEN);
     String requestUrl = String.format(REQUEST_URL_TEMPLATE, okapiUrl, REQUEST_URI_PATH, EVENT_LOG_API_MODULE);
-    HttpRequest<Buffer> request = httpClient.getAbs(requestUrl);
+
+    HttpRequest<Buffer> request = WebClientFactory.getWebClient().getAbs(requestUrl);
     request.putHeader(OKAPI_HEADER_TOKEN, okapiToken)
       .putHeader(OKAPI_HEADER_TENANT, tenantId)
       .putHeader(HTTP_HEADER_CONTENT_TYPE, MediaType.APPLICATION_JSON)

--- a/src/main/java/org/folio/services/impl/LogStorageServiceImpl.java
+++ b/src/main/java/org/folio/services/impl/LogStorageServiceImpl.java
@@ -161,7 +161,7 @@ public class LogStorageServiceImpl implements LogStorageService {
               return;
             }
 
-            int resultCode = deleteReply.result().getUpdated();
+            int resultCode = deleteReply.result().rowCount();
             if (resultCode == 0) {
               asyncResultHandler.handle(Future.succeededFuture(EMPTY_JSON_OBJECT));
               return;

--- a/src/main/java/org/folio/services/impl/PasswordStorageServiceImpl.java
+++ b/src/main/java/org/folio/services/impl/PasswordStorageServiceImpl.java
@@ -1,16 +1,25 @@
 package org.folio.services.impl;
 
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
-import io.vertx.core.http.HttpClient;
-import io.vertx.core.json.JsonObject;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
-import io.vertx.ext.sql.ResultSet;
-import io.vertx.ext.sql.SQLConnection;
-import io.vertx.ext.sql.UpdateResult;
+import static org.folio.rest.RestVerticle.MODULE_SPECIFIC_ARGS;
+import static org.folio.util.Constants.DEFAULT_TIMEOUT;
+import static org.folio.util.Constants.LOOKUP_TIMEOUT;
+import static org.folio.util.LoginConfigUtils.EMPTY_JSON_OBJECT;
+import static org.folio.util.LoginConfigUtils.EVENT_CONFIG_PROXY_STORY_ADDRESS;
+import static org.folio.util.LoginConfigUtils.SNAPSHOTS_TABLE_CREDENTIALS;
+import static org.folio.util.LoginConfigUtils.SNAPSHOTS_TABLE_PW;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+
+import org.folio.cql2pgjson.CQL2PgJSON;
+import org.folio.cql2pgjson.exception.FieldException;
 import org.folio.rest.RestVerticle;
 import org.folio.rest.impl.LoginAPI;
 import org.folio.rest.jaxrs.model.Configurations;
@@ -24,32 +33,29 @@ import org.folio.rest.jaxrs.model.PasswordCreate;
 import org.folio.rest.jaxrs.model.PasswordReset;
 import org.folio.rest.jaxrs.model.ResponseCreateAction;
 import org.folio.rest.jaxrs.model.ResponseResetAction;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.persist.SQLConnection;
 import org.folio.rest.persist.Criteria.Criteria;
 import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.Criteria.Limit;
 import org.folio.rest.persist.Criteria.Order;
-import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.persist.cql.CQLWrapper;
-import org.folio.rest.persist.interfaces.Results;
 import org.folio.services.LogStorageService;
 import org.folio.services.PasswordStorageService;
 import org.folio.util.AuthUtil;
-import org.folio.cql2pgjson.CQL2PgJSON;
-import org.folio.cql2pgjson.exception.FieldException;
 
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MediaType;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.UUID;
-
-import static org.folio.util.LoginConfigUtils.EMPTY_JSON_OBJECT;
-import static org.folio.util.LoginConfigUtils.EVENT_CONFIG_PROXY_STORY_ADDRESS;
-import static org.folio.util.LoginConfigUtils.SNAPSHOTS_TABLE_CREDENTIALS;
-import static org.folio.util.LoginConfigUtils.SNAPSHOTS_TABLE_PW;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
 
 public class PasswordStorageServiceImpl implements PasswordStorageService {
 
@@ -69,12 +75,21 @@ public class PasswordStorageServiceImpl implements PasswordStorageService {
   private final Vertx vertx;
   private AuthUtil authUtil = new AuthUtil();
   private LogStorageService logStorageService;
-  private final HttpClient httpClient;
+  private final WebClient httpClient;
+
+  /**
+   * Timeout to wait for response
+   */
+  private int lookupTimeout = Integer.parseInt(MODULE_SPECIFIC_ARGS.getOrDefault(LOOKUP_TIMEOUT, DEFAULT_TIMEOUT));
 
   public PasswordStorageServiceImpl(Vertx vertx) {
     this.vertx = vertx;
-    httpClient = vertx.createHttpClient();
     logStorageService = LogStorageService.createProxy(vertx, EVENT_CONFIG_PROXY_STORY_ADDRESS);
+
+    WebClientOptions options = new WebClientOptions();
+    options.setConnectTimeout(lookupTimeout);
+    options.setIdleTimeout(lookupTimeout);
+    this.httpClient = WebClient.create(vertx, options);
   }
 
   @Override
@@ -117,12 +132,12 @@ public class PasswordStorageServiceImpl implements PasswordStorageService {
   public PasswordStorageService getPasswordExistence(String userId, String tenantId, Handler<AsyncResult<JsonObject>> asyncHandler) {
     Criterion criterion = getCriterionId(userId, USER_ID_FIELD);
     PostgresClient pgClient = PostgresClient.getInstance(vertx, tenantId);
-    Future<Results<Credential>> future = Future.future();
-    pgClient.get(SNAPSHOTS_TABLE_CREDENTIALS, Credential.class, criterion, true, false, future.completer());
-    future.map(credentialResults -> {
-      boolean credentialFound = credentialResults.getResultInfo().getTotalRecords() == 1;
-      return JsonObject.mapFrom(new CredentialsExistence().withCredentialsExist(credentialFound));
-    }).setHandler(asyncHandler);
+    Promise<JsonObject> promise = Promise.promise();
+    pgClient.get(SNAPSHOTS_TABLE_CREDENTIALS, Credential.class, criterion, true, false,
+        reply -> promise.complete(JsonObject.mapFrom(new CredentialsExistence().withCredentialsExist(reply.result()
+          .getResultInfo()
+          .getTotalRecords() == 1))));
+    promise.future().onComplete(asyncHandler);
     return this;
   }
 
@@ -269,7 +284,7 @@ public class PasswordStorageServiceImpl implements PasswordStorageService {
         } else {
           Credential userCredential = createCredential(newPassword, credentialOpt.get());
           updateCredAndCredHistory(beginTx, userCredential, tenant, token, okapiUrl)
-            .setHandler(v -> {
+            .onComplete(v -> {
               deletePasswordActionById(pgClient, beginTx, asyncHandler, actionId, false);
 
               logStorageService.logEvent(tenant, userId, LogEvent.EventType.PASSWORD_RESET,
@@ -316,7 +331,7 @@ public class PasswordStorageServiceImpl implements PasswordStorageService {
               asyncHandler.handle(Future.failedFuture(rollbackTx.cause())));
           return;
         }
-        int resultCode = deleteReply.result().getUpdated();
+        int resultCode = deleteReply.result().rowCount();
         if (resultCode <= 0) {
           pgClient.rollbackTx(beginTx,
             rollbackTx ->
@@ -387,22 +402,21 @@ public class PasswordStorageServiceImpl implements PasswordStorageService {
     PostgresClient pgClient = PostgresClient.getInstance(vertx, tenant);
     Credential cred = credJson.mapTo(Credential.class);
 
-    pgClient.startTx(conn -> updateCredAndCredHistory(conn, cred, tenant, token, okapiUrl)
-      .setHandler(res -> {
+    pgClient.startTx(handler ->
+      updateCredAndCredHistory(handler, cred, tenant, token, okapiUrl)
+      .onComplete(res -> {
         if (res.failed()) {
-          conn.result().rollback(v -> {
-            conn.result().close();
-            if (v.failed()) {
-              asyncResultHandler.handle(Future.failedFuture(v.cause()));
+          pgClient.rollbackTx(handler, done -> {
+            if (done.failed()) {
+              asyncResultHandler.handle(Future.failedFuture(done.cause()));
             } else {
               asyncResultHandler.handle(Future.failedFuture(res.cause()));
             }
           });
         } else {
-          conn.result().commit(v -> {
-            conn.result().close();
-            if (v.failed()) {
-              asyncResultHandler.handle(Future.failedFuture(v.cause()));
+          pgClient.endTx(handler, done -> {
+            if (done.failed()) {
+              asyncResultHandler.handle(Future.failedFuture(done.cause()));
             } else {
               logStorageService.logEvent(tenant, cred.getUserId(),
                 LogEvent.EventType.PASSWORD_CHANGE, JsonObject.mapFrom(requestHeaders));
@@ -438,7 +452,7 @@ public class PasswordStorageServiceImpl implements PasswordStorageService {
           return getPasswordHistoryNumber(okapiUrl, token, tenant)
             .compose(number -> isPresentInCredHistory(tenant, userId, password, number));
         }
-      }).setHandler(used -> {
+      }).onComplete(used -> {
       if (used.failed()) {
         asyncResultHandler.handle(Future.failedFuture(used.cause()));
         return;
@@ -452,7 +466,7 @@ public class PasswordStorageServiceImpl implements PasswordStorageService {
   private Future<Credential> getCredByUserId(String tenantId, String userId) {
     PostgresClient pgClient = PostgresClient.getInstance(vertx, tenantId);
 
-    Future<Credential> future = Future.future();
+    Promise<Credential> promise = Promise.promise();
     Criteria criteria = new Criteria()
       .addField(USER_ID_FIELD)
       .setOperation("=")
@@ -460,17 +474,17 @@ public class PasswordStorageServiceImpl implements PasswordStorageService {
 
     pgClient.get(TABLE_NAME_CREDENTIALS, Credential.class, new Criterion(criteria), false, false, get -> {
       if (get.failed()) {
-        future.fail(get.cause());
+        promise.fail(get.cause());
       } else {
         List<Credential> credList = get.result().getResults();
         if(credList.isEmpty()) {
-          future.fail("No credential found with that userId");
+          promise.fail("No credential found with that userId");
         } else {
-          future.complete(credList.get(0));
+          promise.complete(credList.get(0));
         }
       }
     });
-    return future;
+    return promise.future();
   }
 
   private Future<Void> updateCredAndCredHistory(AsyncResult<SQLConnection> conn, Credential cred, String tenant,
@@ -484,17 +498,17 @@ public class PasswordStorageServiceImpl implements PasswordStorageService {
   private Future<Credential> updateCred(AsyncResult<SQLConnection> conn, String tenantId,
                                         Credential newCred, Credential oldCred) {
     PostgresClient pgClient = PostgresClient.getInstance(vertx, tenantId);
-    Future<UpdateResult> future = Future.future();
+    Promise<Credential> promise = Promise.promise();
     CQL2PgJSON field = null;
     try {
       field = new CQL2PgJSON(TABLE_NAME_CREDENTIALS + ".jsonb");
     } catch (FieldException e) {
-      future.fail(e);
+      promise.fail(e);
     }
     CQLWrapper cqlWrapper = new CQLWrapper(field, "id==" + newCred.getId());
-    pgClient.update(conn, TABLE_NAME_CREDENTIALS, newCred, cqlWrapper, true, future.completer());
+    pgClient.update(conn, TABLE_NAME_CREDENTIALS, newCred, cqlWrapper, true, reply -> promise.complete(oldCred));
 
-    return future.map(updateResult -> oldCred);
+    return promise.future();
   }
 
   private Future<Void> updateCredHistory(AsyncResult<SQLConnection> conn, Credential cred,
@@ -503,9 +517,9 @@ public class PasswordStorageServiceImpl implements PasswordStorageService {
     return getCredHistoryCountByUserId(tenant, cred.getUserId())
       .compose(count -> getPasswordHistoryNumber(okapiUrl, token, tenant)
         .map(number -> count - number + 2))
-      .compose(count -> deleteOldCredHistoryRecords(conn, tenant, cred.getUserId(), count))
+      .compose(count -> deleteOldCredHistoryRecords(tenant, cred.getUserId(), count))
       .compose(v -> {
-        Future<String> future = Future.future();
+        Promise<Void> promise = Promise.promise();
         CredentialsHistory credHistory = new CredentialsHistory();
         credHistory.setId(UUID.randomUUID().toString());
         credHistory.setUserId(cred.getUserId());
@@ -515,9 +529,9 @@ public class PasswordStorageServiceImpl implements PasswordStorageService {
 
         PostgresClient pgClient = PostgresClient.getInstance(vertx, tenant);
         pgClient.save(conn, TABLE_NAME_CREDENTIALS_HISTORY, UUID.randomUUID().toString(),
-          credHistory, future.completer());
+          credHistory, done -> promise.complete());
 
-        return future.map(s -> null);
+        return promise.future();
       });
   }
 
@@ -525,34 +539,33 @@ public class PasswordStorageServiceImpl implements PasswordStorageService {
     PostgresClient pgClient = PostgresClient.getInstance(vertx, tenantId);
     String tableName = String.format(
       "%s.%s", PostgresClient.convertToPsqlStandard(tenantId), TABLE_NAME_CREDENTIALS_HISTORY);
-    Future<ResultSet> future = Future.future();
+    Promise<Integer> promise = Promise.promise();
     String query = String.format("SELECT count(id) FROM %s WHERE jsonb->>'userId' = '%s'", tableName, userId);
-    pgClient.select(query, future.completer());
-
-    return future.map(resultSet -> resultSet.getResults().get(0).getInteger(0));
+    pgClient.select(query, reply -> promise.complete(reply.result().iterator().next().getInteger(0)));
+    return promise.future();
   }
 
-  private Future<Void> deleteOldCredHistoryRecords(AsyncResult<SQLConnection> conn, String tenantId,
-                                                   String userId, Integer count) {
+  private Future<Void> deleteOldCredHistoryRecords(String tenantId, String userId, Integer count) {
     if (count < 1) {
       return Future.succeededFuture();
     }
 
-    Future<Void> future = Future.future();
+    PostgresClient pgClient = PostgresClient.getInstance(vertx, tenantId);
+    Promise<Void> promise = Promise.promise();
     String tableName = String.format(
       "%s.%s", PostgresClient.convertToPsqlStandard(tenantId), TABLE_NAME_CREDENTIALS_HISTORY);
 
     String query = String.format("DELETE FROM %s WHERE id IN " +
         "(SELECT id FROM %s WHERE jsonb->>'userId' = '%s' ORDER BY jsonb->>'date' ASC LIMIT %d)",
       tableName, tableName, userId, count);
-    conn.result().execute(query, future.completer());
+    pgClient.execute(query, done -> promise.complete());
 
-    return future;
+    return promise.future();
   }
 
   private Future<Boolean> isPresentInCredHistory(String tenantId, String userId,
                                                  String password, int pwdHistoryNumber) {
-    Future<Boolean> future = Future.future();
+    Promise<Boolean> promise = Promise.promise();
     PostgresClient pgClient = PostgresClient.getInstance(vertx, tenantId);
 
     Criteria criteria = new Criteria()
@@ -566,7 +579,7 @@ public class PasswordStorageServiceImpl implements PasswordStorageService {
 
     pgClient.get(TABLE_NAME_CREDENTIALS_HISTORY, CredentialsHistory.class, criterion, true, get -> {
       if (get.failed()) {
-        future.fail(get.cause());
+        promise.fail(get.cause());
         return;
       }
 
@@ -575,33 +588,37 @@ public class PasswordStorageServiceImpl implements PasswordStorageService {
         .anyMatch(hash -> get.result().getResults().stream()
           .anyMatch(history -> history.getHash().equals(hash)));
 
-      future.complete(anyMatch);
+      promise.complete(anyMatch);
     });
 
-    return future;
+    return promise.future();
   }
 
   private Future<Integer> getPasswordHistoryNumber(String okapiUrl, String token, String tenant) {
-    Future<Integer> future = Future.future();
+    Promise<Integer> promise = Promise.promise();
 
     httpClient.getAbs(okapiUrl + PW_HISTORY_NUMBER_CONF_PATH)
       .putHeader(HttpHeaders.ACCEPT, MediaType.TEXT_PLAIN)
       .putHeader(RestVerticle.OKAPI_HEADER_TOKEN, token)
       .putHeader(RestVerticle.OKAPI_HEADER_TENANT, tenant)
-      .exceptionHandler(throwable -> future.complete(DEFAULT_PASSWORDS_HISTORY_NUMBER))
-      .handler(resp -> resp.bodyHandler(body -> {
-        if (resp.statusCode() != 200) {
-          future.complete(DEFAULT_PASSWORDS_HISTORY_NUMBER);
+      .send(ar -> {
+        if(ar.failed()) {
+          promise.complete(DEFAULT_PASSWORDS_HISTORY_NUMBER);
         } else {
-          Configurations conf = body.toJsonObject().mapTo(Configurations.class);
-          if (conf.getConfigs().isEmpty()) {
-            future.complete(DEFAULT_PASSWORDS_HISTORY_NUMBER);
-            return;
+          HttpResponse<Buffer> resp = ar.result();
+          if (resp.statusCode() != 200) {
+            promise.complete(DEFAULT_PASSWORDS_HISTORY_NUMBER);
+          } else {
+            Configurations conf = resp.bodyAsJson(Configurations.class);
+            if (conf.getConfigs().isEmpty()) {
+              promise.complete(DEFAULT_PASSWORDS_HISTORY_NUMBER);
+              return;
+            }
+            promise.complete(Integer.valueOf(conf.getConfigs().get(0).getValue()));
           }
-          future.complete(Integer.valueOf(conf.getConfigs().get(0).getValue()));
         }
-      })).end();
+      });
 
-    return future;
+    return promise.future();
   }
 }

--- a/src/main/java/org/folio/services/impl/PasswordStorageServiceImpl.java
+++ b/src/main/java/org/folio/services/impl/PasswordStorageServiceImpl.java
@@ -581,7 +581,7 @@ public class PasswordStorageServiceImpl implements PasswordStorageService {
   private Future<Integer> getPasswordHistoryNumber(String okapiUrl, String token, String tenant) {
     Promise<Integer> promise = Promise.promise();
 
-    WebClientFactory.getWebClient().getAbs(okapiUrl + PW_HISTORY_NUMBER_CONF_PATH)
+    WebClientFactory.getWebClient(vertx).getAbs(okapiUrl + PW_HISTORY_NUMBER_CONF_PATH)
       .putHeader(HttpHeaders.ACCEPT, MediaType.TEXT_PLAIN)
       .putHeader(RestVerticle.OKAPI_HEADER_TOKEN, token)
       .putHeader(RestVerticle.OKAPI_HEADER_TENANT, tenant)

--- a/src/main/java/org/folio/services/impl/PasswordStorageServiceImpl.java
+++ b/src/main/java/org/folio/services/impl/PasswordStorageServiceImpl.java
@@ -1,8 +1,5 @@
 package org.folio.services.impl;
 
-import static org.folio.rest.RestVerticle.MODULE_SPECIFIC_ARGS;
-import static org.folio.util.Constants.DEFAULT_TIMEOUT;
-import static org.folio.util.Constants.LOOKUP_TIMEOUT;
 import static org.folio.util.LoginConfigUtils.EMPTY_JSON_OBJECT;
 import static org.folio.util.LoginConfigUtils.EVENT_CONFIG_PROXY_STORY_ADDRESS;
 import static org.folio.util.LoginConfigUtils.SNAPSHOTS_TABLE_CREDENTIALS;
@@ -43,6 +40,7 @@ import org.folio.rest.persist.cql.CQLWrapper;
 import org.folio.services.LogStorageService;
 import org.folio.services.PasswordStorageService;
 import org.folio.util.AuthUtil;
+import org.folio.util.WebClientFactory;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
@@ -54,8 +52,6 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.web.client.HttpResponse;
-import io.vertx.ext.web.client.WebClient;
-import io.vertx.ext.web.client.WebClientOptions;
 
 public class PasswordStorageServiceImpl implements PasswordStorageService {
 
@@ -75,21 +71,10 @@ public class PasswordStorageServiceImpl implements PasswordStorageService {
   private final Vertx vertx;
   private AuthUtil authUtil = new AuthUtil();
   private LogStorageService logStorageService;
-  private final WebClient httpClient;
-
-  /**
-   * Timeout to wait for response
-   */
-  private int lookupTimeout = Integer.parseInt(MODULE_SPECIFIC_ARGS.getOrDefault(LOOKUP_TIMEOUT, DEFAULT_TIMEOUT));
 
   public PasswordStorageServiceImpl(Vertx vertx) {
     this.vertx = vertx;
     logStorageService = LogStorageService.createProxy(vertx, EVENT_CONFIG_PROXY_STORY_ADDRESS);
-
-    WebClientOptions options = new WebClientOptions();
-    options.setConnectTimeout(lookupTimeout);
-    options.setIdleTimeout(lookupTimeout);
-    this.httpClient = WebClient.create(vertx, options);
   }
 
   @Override
@@ -597,7 +582,7 @@ public class PasswordStorageServiceImpl implements PasswordStorageService {
   private Future<Integer> getPasswordHistoryNumber(String okapiUrl, String token, String tenant) {
     Promise<Integer> promise = Promise.promise();
 
-    httpClient.getAbs(okapiUrl + PW_HISTORY_NUMBER_CONF_PATH)
+    WebClientFactory.getWebClient().getAbs(okapiUrl + PW_HISTORY_NUMBER_CONF_PATH)
       .putHeader(HttpHeaders.ACCEPT, MediaType.TEXT_PLAIN)
       .putHeader(RestVerticle.OKAPI_HEADER_TOKEN, token)
       .putHeader(RestVerticle.OKAPI_HEADER_TENANT, tenant)

--- a/src/main/java/org/folio/services/impl/PasswordStorageServiceImpl.java
+++ b/src/main/java/org/folio/services/impl/PasswordStorageServiceImpl.java
@@ -490,7 +490,7 @@ public class PasswordStorageServiceImpl implements PasswordStorageService {
   private Future<Credential> updateCred(AsyncResult<SQLConnection> conn, String tenantId,
                                         Credential newCred, Credential oldCred) {
     PostgresClient pgClient = PostgresClient.getInstance(vertx, tenantId);
-    Promise<Credential> promise = Promise.promise();
+    Promise<RowSet<Row>> promise = Promise.promise();
     CQL2PgJSON field = null;
     try {
       field = new CQL2PgJSON(TABLE_NAME_CREDENTIALS + ".jsonb");
@@ -498,14 +498,8 @@ public class PasswordStorageServiceImpl implements PasswordStorageService {
       promise.fail(e);
     }
     CQLWrapper cqlWrapper = new CQLWrapper(field, "id==" + newCred.getId());
-    pgClient.update(conn, TABLE_NAME_CREDENTIALS, newCred, cqlWrapper, true, reply -> {
-      if (reply.failed()) {
-        promise.fail(reply.cause());
-      } else {
-        promise.complete(oldCred);
-      }
-    });
-    return promise.future();
+    pgClient.update(conn, TABLE_NAME_CREDENTIALS, newCred, cqlWrapper, true, promise);
+    return promise.future().map(updated -> oldCred);
   }
 
   private Future<Void> updateCredHistory(AsyncResult<SQLConnection> conn, Credential cred,
@@ -516,7 +510,7 @@ public class PasswordStorageServiceImpl implements PasswordStorageService {
         .map(number -> count - number + 2))
       .compose(count -> deleteOldCredHistoryRecords(tenant, cred.getUserId(), count))
       .compose(v -> {
-        Promise<Void> promise = Promise.promise();
+        Promise<String> promise = Promise.promise();
         CredentialsHistory credHistory = new CredentialsHistory();
         credHistory.setId(UUID.randomUUID().toString());
         credHistory.setUserId(cred.getUserId());
@@ -525,14 +519,8 @@ public class PasswordStorageServiceImpl implements PasswordStorageService {
         credHistory.setDate(new Date());
 
         PostgresClient pgClient = PostgresClient.getInstance(vertx, tenant);
-        pgClient.save(conn, TABLE_NAME_CREDENTIALS_HISTORY, UUID.randomUUID().toString(), credHistory, reply -> {
-          if (reply.failed()) {
-            promise.fail(reply.cause());
-          } else {
-            promise.complete();
-          }
-        });
-        return promise.future();
+        pgClient.save(conn, TABLE_NAME_CREDENTIALS_HISTORY, UUID.randomUUID().toString(), credHistory, promise);
+        return promise.future().map(s -> null);
       });
   }
 
@@ -540,16 +528,10 @@ public class PasswordStorageServiceImpl implements PasswordStorageService {
     PostgresClient pgClient = PostgresClient.getInstance(vertx, tenantId);
     String tableName = String.format(
       "%s.%s", PostgresClient.convertToPsqlStandard(tenantId), TABLE_NAME_CREDENTIALS_HISTORY);
-    Promise<Integer> promise = Promise.promise();
+    Promise<RowSet<Row>> promise = Promise.promise();
     String query = String.format("SELECT count(id) FROM %s WHERE jsonb->>'userId' = '%s'", tableName, userId);
-    pgClient.select(query, reply -> {
-      if(reply.failed()) {
-        promise.fail(reply.cause());
-      } else {
-        promise.complete(reply.result().iterator().next().getInteger(0));
-      }
-    });
-    return promise.future();
+    pgClient.select(query, promise);
+    return promise.future().map(resultSet -> resultSet.iterator().next().getInteger(0));
   }
 
   private Future<Void> deleteOldCredHistoryRecords(String tenantId, String userId, Integer count) {
@@ -558,21 +540,15 @@ public class PasswordStorageServiceImpl implements PasswordStorageService {
     }
 
     PostgresClient pgClient = PostgresClient.getInstance(vertx, tenantId);
-    Promise<Void> promise = Promise.promise();
+    Promise<RowSet<Row>> promise = Promise.promise();
     String tableName = String.format(
       "%s.%s", PostgresClient.convertToPsqlStandard(tenantId), TABLE_NAME_CREDENTIALS_HISTORY);
 
     String query = String.format("DELETE FROM %s WHERE id IN " +
         "(SELECT id FROM %s WHERE jsonb->>'userId' = '%s' ORDER BY jsonb->>'date' ASC LIMIT %d)",
       tableName, tableName, userId, count);
-    pgClient.execute(query, reply -> {
-      if (reply.failed()) {
-        promise.fail(reply.cause());
-      } else {
-        promise.complete();
-      }
-    });
-    return promise.future();
+    pgClient.execute(query, promise);
+    return promise.future().map(s -> null);
   }
 
   private Future<Boolean> isPresentInCredHistory(String tenantId, String userId,

--- a/src/main/java/org/folio/util/Constants.java
+++ b/src/main/java/org/folio/util/Constants.java
@@ -1,7 +1,6 @@
 package org.folio.util;
 
 public final class Constants {
-  public static final String HTTP_CLIENT = "httpClient";
   public static final String LOOKUP_TIMEOUT = "lookup.timeout";
   public static final String DEFAULT_TIMEOUT = "1000";
 

--- a/src/main/java/org/folio/util/LoginAttemptsHelper.java
+++ b/src/main/java/org/folio/util/LoginAttemptsHelper.java
@@ -6,8 +6,6 @@ import static org.folio.rest.impl.LoginAPI.OKAPI_TENANT_HEADER;
 import static org.folio.rest.impl.LoginAPI.OKAPI_TOKEN_HEADER;
 import static org.folio.util.LoginConfigUtils.EVENT_CONFIG_PROXY_STORY_ADDRESS;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -187,16 +185,6 @@ public class LoginAttemptsHelper {
     }
   }
 
-  private String encodeUtf8(String s) {
-    String ret = null;
-    try {
-      ret = URLEncoder.encode(s, "UTF-8");
-    } catch (UnsupportedEncodingException e) {
-      // Should never happen - UTF-8 is supported
-    }
-    return ret;
-  }
-
   /**
    * Load config object by code for login module
    *
@@ -211,7 +199,7 @@ public class LoginAttemptsHelper {
     String requestToken = okapiHeaders.get(RestVerticle.OKAPI_HEADER_TOKEN);
     String okapiUrl = okapiHeaders.get(LoginAPI.OKAPI_URL_HEADER);
 
-    requestURL = okapiUrl + "/configurations/entries?query=" + "code==" + encodeUtf8(configCode);
+    requestURL = okapiUrl + "/configurations/entries?query=" + "code==" + StringUtil.urlEncode(configCode);
     HttpRequest<Buffer> request = WebClientFactory.getWebClient().getAbs(requestURL);
     request.putHeader(OKAPI_TENANT_HEADER, tenant)
       .putHeader(OKAPI_TOKEN_HEADER, requestToken)
@@ -268,7 +256,7 @@ public class LoginAttemptsHelper {
     String requestToken = okapiHeaders.get(RestVerticle.OKAPI_HEADER_TOKEN);
     String okapiUrl = okapiHeaders.get(LoginAPI.OKAPI_URL_HEADER);
 
-    requestURL = okapiUrl + "/users/" + encodeUtf8(user.getString("id"));
+    requestURL = okapiUrl + "/users/" + StringUtil.urlEncode(user.getString("id"));
     HttpRequest<Buffer> request = WebClientFactory.getWebClient().putAbs(requestURL);
     request.putHeader(OKAPI_TENANT_HEADER, tenant)
       .putHeader(OKAPI_TOKEN_HEADER, requestToken)

--- a/src/main/java/org/folio/util/LoginAttemptsHelper.java
+++ b/src/main/java/org/folio/util/LoginAttemptsHelper.java
@@ -4,8 +4,6 @@ import static org.folio.rest.RestVerticle.MODULE_SPECIFIC_ARGS;
 import static org.folio.rest.impl.LoginAPI.CODE_FIFTH_FAILED_ATTEMPT_BLOCKED;
 import static org.folio.rest.impl.LoginAPI.OKAPI_TENANT_HEADER;
 import static org.folio.rest.impl.LoginAPI.OKAPI_TOKEN_HEADER;
-import static org.folio.util.Constants.DEFAULT_TIMEOUT;
-import static org.folio.util.Constants.LOOKUP_TIMEOUT;
 import static org.folio.util.LoginConfigUtils.EVENT_CONFIG_PROXY_STORY_ADDRESS;
 
 import java.net.URLEncoder;
@@ -36,8 +34,6 @@ import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.HttpResponse;
-import io.vertx.ext.web.client.WebClient;
-import io.vertx.ext.web.client.WebClientOptions;
 
 /**
  * Helper class that contains static methods which helps with processing Login Attempts business logic
@@ -54,22 +50,11 @@ public class LoginAttemptsHelper {
   private static final String VALUE = "value";
 
   private Vertx vertx;
-  private WebClient httpClient;
   private LogStorageService logStorageService;
-
-  /**
-   * Timeout to wait for response
-   */
-  private int lookupTimeout = Integer.parseInt(MODULE_SPECIFIC_ARGS.getOrDefault(LOOKUP_TIMEOUT, DEFAULT_TIMEOUT));
 
   public LoginAttemptsHelper(Vertx vertx) {
     this.vertx = vertx;
     logStorageService = LogStorageService.createProxy(vertx, EVENT_CONFIG_PROXY_STORY_ADDRESS);
-
-    WebClientOptions options = new WebClientOptions();
-    options.setConnectTimeout(lookupTimeout);
-    options.setIdleTimeout(lookupTimeout);
-    this.httpClient = WebClient.create(vertx, options);
   }
 
   /**
@@ -244,7 +229,7 @@ public class LoginAttemptsHelper {
       return promise.future();
     }
     try {
-      HttpRequest<Buffer> request = httpClient.getAbs(requestURL);
+      HttpRequest<Buffer> request = WebClientFactory.getWebClient().getAbs(requestURL);
       request.putHeader(OKAPI_TENANT_HEADER, tenant)
         .putHeader(OKAPI_TOKEN_HEADER, requestToken)
         .putHeader("Content-type", JSON_TYPE)
@@ -314,7 +299,7 @@ public class LoginAttemptsHelper {
       return promise.future();
     }
     try {
-      HttpRequest<Buffer> request = httpClient.putAbs(requestURL);
+      HttpRequest<Buffer> request = WebClientFactory.getWebClient().putAbs(requestURL);
       request.putHeader(OKAPI_TENANT_HEADER, tenant)
         .putHeader(OKAPI_TOKEN_HEADER, requestToken)
         .putHeader("Content-type", JSON_TYPE)

--- a/src/main/java/org/folio/util/LoginAttemptsHelper.java
+++ b/src/main/java/org/folio/util/LoginAttemptsHelper.java
@@ -200,7 +200,7 @@ public class LoginAttemptsHelper {
     String okapiUrl = okapiHeaders.get(LoginAPI.OKAPI_URL_HEADER);
 
     requestURL = okapiUrl + "/configurations/entries?query=" + "code==" + StringUtil.urlEncode(configCode);
-    HttpRequest<Buffer> request = WebClientFactory.getWebClient().getAbs(requestURL);
+    HttpRequest<Buffer> request = WebClientFactory.getWebClient(vertx).getAbs(requestURL);
     request.putHeader(OKAPI_TENANT_HEADER, tenant)
       .putHeader(OKAPI_TOKEN_HEADER, requestToken)
       .putHeader("Content-type", JSON_TYPE)
@@ -257,7 +257,7 @@ public class LoginAttemptsHelper {
     String okapiUrl = okapiHeaders.get(LoginAPI.OKAPI_URL_HEADER);
 
     requestURL = okapiUrl + "/users/" + StringUtil.urlEncode(user.getString("id"));
-    HttpRequest<Buffer> request = WebClientFactory.getWebClient().putAbs(requestURL);
+    HttpRequest<Buffer> request = WebClientFactory.getWebClient(vertx).putAbs(requestURL);
     request.putHeader(OKAPI_TENANT_HEADER, tenant)
       .putHeader(OKAPI_TOKEN_HEADER, requestToken)
       .putHeader("Content-type", JSON_TYPE)

--- a/src/main/java/org/folio/util/LoginAttemptsHelper.java
+++ b/src/main/java/org/folio/util/LoginAttemptsHelper.java
@@ -310,9 +310,9 @@ public class LoginAttemptsHelper {
         } else {
           HttpResponse<Buffer> res = ar.result();
           if (res.statusCode() != 204) {
-            Buffer buf = res.bodyAsBuffer();
+            String body = res.bodyAsString();
               String message = "Expected status code 204, got '" + res.statusCode() +
-                "' :" + buf.toString();
+                "' :" + body;
               promise.fail(message);
           } else {
             promise.complete();

--- a/src/main/java/org/folio/util/WebClientFactory.java
+++ b/src/main/java/org/folio/util/WebClientFactory.java
@@ -1,0 +1,31 @@
+package org.folio.util;
+
+import static org.folio.rest.RestVerticle.MODULE_SPECIFIC_ARGS;
+import static org.folio.util.Constants.DEFAULT_TIMEOUT;
+import static org.folio.util.Constants.LOOKUP_TIMEOUT;
+
+import io.vertx.core.Vertx;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
+
+public class WebClientFactory {
+
+  private WebClient client;
+
+  public static WebClient getWebClient() {
+    return WebClientSingletonHolder.INSTANCE.client;
+  }
+
+  private WebClientFactory() {
+    int lookupTimeout = Integer.parseInt(MODULE_SPECIFIC_ARGS.getOrDefault(LOOKUP_TIMEOUT, DEFAULT_TIMEOUT));
+
+    WebClientOptions options = new WebClientOptions();
+    options.setConnectTimeout(lookupTimeout);
+    options.setIdleTimeout(lookupTimeout);
+    client = WebClient.create(Vertx.vertx(), options);
+  }
+  
+  private static class WebClientSingletonHolder {
+    private static final WebClientFactory INSTANCE = new WebClientFactory();
+  }
+}

--- a/src/main/java/org/folio/util/WebClientFactory.java
+++ b/src/main/java/org/folio/util/WebClientFactory.java
@@ -4,28 +4,30 @@ import static org.folio.rest.RestVerticle.MODULE_SPECIFIC_ARGS;
 import static org.folio.util.Constants.DEFAULT_TIMEOUT;
 import static org.folio.util.Constants.LOOKUP_TIMEOUT;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
 
 public class WebClientFactory {
 
-  private WebClient client;
+  private static Map<Vertx, WebClient> clients = new HashMap<>();
 
-  public static WebClient getWebClient() {
-    return WebClientSingletonHolder.INSTANCE.client;
+  public static WebClient getWebClient(Vertx vertx) {
+    return clients.get(vertx);
   }
 
   private WebClientFactory() {
+  }
+
+  public static void init(Vertx vertx) {
     int lookupTimeout = Integer.parseInt(MODULE_SPECIFIC_ARGS.getOrDefault(LOOKUP_TIMEOUT, DEFAULT_TIMEOUT));
 
     WebClientOptions options = new WebClientOptions();
     options.setConnectTimeout(lookupTimeout);
     options.setIdleTimeout(lookupTimeout);
-    client = WebClient.create(Vertx.vertx(), options);
-  }
-  
-  private static class WebClientSingletonHolder {
-    private static final WebClientFactory INSTANCE = new WebClientFactory();
+    clients.put(vertx, WebClient.create(vertx, options));
   }
 }

--- a/src/main/java/org/folio/util/WebClientFactory.java
+++ b/src/main/java/org/folio/util/WebClientFactory.java
@@ -22,12 +22,20 @@ public class WebClientFactory {
   private WebClientFactory() {
   }
 
-  public static void init(Vertx vertx) {
-    int lookupTimeout = Integer.parseInt(MODULE_SPECIFIC_ARGS.getOrDefault(LOOKUP_TIMEOUT, DEFAULT_TIMEOUT));
+  /**
+   * Initializes a WebClient for the provided Vertx.
+   * Calling this method more than once with the same Vertx has no effect.
+   *
+   * @param vertx
+   */
+  public static synchronized void init(Vertx vertx) {
+    if (vertx != null && !clients.containsKey(vertx)) {
+      int lookupTimeout = Integer.parseInt(MODULE_SPECIFIC_ARGS.getOrDefault(LOOKUP_TIMEOUT, DEFAULT_TIMEOUT));
 
-    WebClientOptions options = new WebClientOptions();
-    options.setConnectTimeout(lookupTimeout);
-    options.setIdleTimeout(lookupTimeout);
-    clients.put(vertx, WebClient.create(vertx, options));
+      WebClientOptions options = new WebClientOptions();
+      options.setConnectTimeout(lookupTimeout);
+      options.setIdleTimeout(lookupTimeout);
+      clients.put(vertx, WebClient.create(vertx, options));
+    }
   }
 }

--- a/src/test/java/org/folio/logintest/CredentialExistenceTest.java
+++ b/src/test/java/org/folio/logintest/CredentialExistenceTest.java
@@ -6,6 +6,7 @@ import io.restassured.http.ContentType;
 import io.restassured.specification.RequestSpecification;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
@@ -65,7 +66,7 @@ public class CredentialExistenceTest {
       try {
         TenantAttributes ta = new TenantAttributes().withModuleTo("mod-login-1.1.0");
         tenantClient.postTenant(ta, handler -> saveCredential()
-          .setHandler(v -> {
+          .onComplete(v -> {
             if (v.succeeded()) {
               async.complete();
             }
@@ -122,7 +123,7 @@ public class CredentialExistenceTest {
   }
 
   private static Future<Void> saveCredential() {
-    Future<String> future = Future.future();
+    Promise<Void> promise = Promise.promise();
     String salt = authUtil.getSalt();
     Credential credential = new Credential();
     credential.setId(UUID.randomUUID().toString());
@@ -130,8 +131,8 @@ public class CredentialExistenceTest {
     credential.setHash(authUtil.calculateHash("password", salt));
     credential.setUserId(EXISTING_CREDENTIALS_USER_ID);
     PostgresClient.getInstance(vertx, TENANT).save(TABLE_NAME_CREDENTIALS, UUID.randomUUID().toString(),
-      credential, future.completer());
-    return future.map(s -> null);
+      credential, done -> promise.complete());
+    return promise.future();
   }
 
 }

--- a/src/test/java/org/folio/logintest/CredentialExistenceTest.java
+++ b/src/test/java/org/folio/logintest/CredentialExistenceTest.java
@@ -130,9 +130,14 @@ public class CredentialExistenceTest {
     credential.setSalt(salt);
     credential.setHash(authUtil.calculateHash("password", salt));
     credential.setUserId(EXISTING_CREDENTIALS_USER_ID);
-    PostgresClient.getInstance(vertx, TENANT).save(TABLE_NAME_CREDENTIALS, UUID.randomUUID().toString(),
-      credential, done -> promise.complete());
+    PostgresClient.getInstance(vertx, TENANT)
+      .save(TABLE_NAME_CREDENTIALS, UUID.randomUUID().toString(), credential, reply -> {
+        if (reply.failed()) {
+          promise.fail(reply.cause());
+        } else {
+          promise.complete();
+        }
+      });
     return promise.future();
   }
-
 }

--- a/src/test/java/org/folio/logintest/CredentialExistenceTest.java
+++ b/src/test/java/org/folio/logintest/CredentialExistenceTest.java
@@ -123,7 +123,7 @@ public class CredentialExistenceTest {
   }
 
   private static Future<Void> saveCredential() {
-    Promise<Void> promise = Promise.promise();
+    Promise<String> promise = Promise.promise();
     String salt = authUtil.getSalt();
     Credential credential = new Credential();
     credential.setId(UUID.randomUUID().toString());
@@ -131,13 +131,7 @@ public class CredentialExistenceTest {
     credential.setHash(authUtil.calculateHash("password", salt));
     credential.setUserId(EXISTING_CREDENTIALS_USER_ID);
     PostgresClient.getInstance(vertx, TENANT)
-      .save(TABLE_NAME_CREDENTIALS, UUID.randomUUID().toString(), credential, reply -> {
-        if (reply.failed()) {
-          promise.fail(reply.cause());
-        } else {
-          promise.complete();
-        }
-      });
-    return promise.future();
+      .save(TABLE_NAME_CREDENTIALS, UUID.randomUUID().toString(), credential, promise);
+    return promise.future().map(s -> null);
   }
 }

--- a/src/test/java/org/folio/logintest/EventsLoggingTests.java
+++ b/src/test/java/org/folio/logintest/EventsLoggingTests.java
@@ -116,7 +116,7 @@ public class EventsLoggingTests {
       .compose(v -> postTenant())
       .compose(v -> persistCredentials())
       .compose(v -> persistPasswordResetActions())
-      .setHandler(context.asyncAssertSuccess());
+      .onComplete(context.asyncAssertSuccess());
   }
 
   @After

--- a/src/test/java/org/folio/logintest/PasswordRepeatabilityValidationTest.java
+++ b/src/test/java/org/folio/logintest/PasswordRepeatabilityValidationTest.java
@@ -200,7 +200,13 @@ public class PasswordRepeatabilityValidationTest {
     credential.setHash(authUtil.calculateHash(CURRENT_PASSWORD, salt));
     credential.setUserId(USER_ID);
     PostgresClient.getInstance(vertx, TENANT).save(TABLE_NAME_CREDENTIALS, UUID.randomUUID().toString(),
-      credential, done -> promise.complete());
+      credential, reply -> {
+        if (reply.failed()) {
+          promise.fail(reply.cause());
+        } else {
+          promise.complete();
+        }
+      });
     return promise.future();
   }
 

--- a/src/test/java/org/folio/logintest/PasswordRepeatabilityValidationTest.java
+++ b/src/test/java/org/folio/logintest/PasswordRepeatabilityValidationTest.java
@@ -166,7 +166,7 @@ public class PasswordRepeatabilityValidationTest {
   }
 
   private static Future<Void> fillInCredentialsHistory() {
-    Promise<Void> promise = Promise.promise();
+    Promise<CompositeFuture> promise = Promise.promise();
 
     //add ten passwords
     List<Future> list = IntStream.range(0, PASSWORDS_HISTORY_NUMBER - 1)
@@ -180,49 +180,31 @@ public class PasswordRepeatabilityValidationTest {
     list.add(saveCredentialsHistoryObject(buildCredentialsHistoryObject(
       OLD_PASSWORD, new Date(new Date().getTime() - hourMillis))));
 
-    CompositeFuture.all(list).onComplete(event -> {
-      if (event.succeeded()) {
-        promise.complete();
-      } else {
-        promise.fail(event.cause());
-      }
-    });
+    CompositeFuture.all(list).onComplete(promise);
 
-    return promise.future();
+    return promise.future().map(s -> null);
   }
 
   private static Future<Void> saveCredential() {
-    Promise<Void> promise = Promise.promise();
+    Promise<String> promise = Promise.promise();
     String salt = authUtil.getSalt();
     Credential credential = new Credential();
     credential.setId(UUID.randomUUID().toString());
     credential.setSalt(salt);
     credential.setHash(authUtil.calculateHash(CURRENT_PASSWORD, salt));
     credential.setUserId(USER_ID);
-    PostgresClient.getInstance(vertx, TENANT).save(TABLE_NAME_CREDENTIALS, UUID.randomUUID().toString(),
-      credential, reply -> {
-        if (reply.failed()) {
-          promise.fail(reply.cause());
-        } else {
-          promise.complete();
-        }
-      });
-    return promise.future();
+    PostgresClient.getInstance(vertx, TENANT)
+      .save(TABLE_NAME_CREDENTIALS, UUID.randomUUID().toString(), credential, promise);
+    return promise.future().map(s -> null);
   }
 
   private static Future<Void> saveCredentialsHistoryObject(CredentialsHistory obj) {
-    Promise<Void> promise = Promise.promise();
+    Promise<String> promise = Promise.promise();
 
     PostgresClient client = PostgresClient.getInstance(vertx, TENANT);
-    client.save(TABLE_NAME_CREDENTIALS_HISTORY, UUID.randomUUID().toString(), obj, event -> {
-      if (event.failed()) {
-        promise.fail(event.cause());
-      } else {
-        promise.complete();
-      }
-    });
+    client.save(TABLE_NAME_CREDENTIALS_HISTORY, UUID.randomUUID().toString(), obj, promise);
 
-    return promise.future();
+    return promise.future().map(s -> null);
   }
 
   private static CredentialsHistory buildCredentialsHistoryObject(String password) {

--- a/src/test/java/org/folio/logintest/RestVerticleTest.java
+++ b/src/test/java/org/folio/logintest/RestVerticleTest.java
@@ -92,6 +92,10 @@ public class RestVerticleTest {
       .put("username", "gandalf")
       .put("password", "54321");
 
+  private JsonObject credsUserWithNoId = new JsonObject()
+      .put("username", "strider")
+      .put("password", "54321");
+
   private static Vertx vertx;
   private static int port;
   private static int mockPort;
@@ -222,6 +226,7 @@ public class RestVerticleTest {
         .compose(w -> doLoginBadUserResponse(context, credsElicitBadUserResp))
         .compose(w -> doLoginNonExistentUser(context, credsNonExistentUser))
         .compose(w -> doLoginMultiUserRespose(context, credsElicitMultiUserResp))
+        .compose(w -> doLoginNoUserId(context, credsUserWithNoId))
         .compose(w -> doLogin(context, credsObject1))
         .compose(w -> doLogin(context, credsObject2))
         .compose(w -> postNewCredentials(context, credsObject3))
@@ -334,6 +339,11 @@ public class RestVerticleTest {
   private Future<WrappedResponse> doLoginNoUsernameOrUserId(TestContext context, JsonObject loginCredentials) {
     return doRequest(vertx, loginUrl, HttpMethod.POST, headers, loginCredentials.encode(),
       400, "You must provide a username or userId");
+  }
+
+  private Future<WrappedResponse> doLoginNoUserId(TestContext context, JsonObject loginCredentials) {
+    return doRequest(vertx, loginUrl, HttpMethod.POST, headers, loginCredentials.encode(),
+      500, "No user id could be found");
   }
 
   private Future<WrappedResponse> doLoginNoPassword(TestContext context, JsonObject loginCredentials) {

--- a/src/test/java/org/folio/logintest/RestVerticleTest.java
+++ b/src/test/java/org/folio/logintest/RestVerticleTest.java
@@ -1,27 +1,22 @@
 package org.folio.logintest;
 
-import io.vertx.core.DeploymentOptions;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.MultiMap;
-import io.vertx.core.Vertx;
-import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.HttpClient;
-import io.vertx.core.http.HttpClientRequest;
-import io.vertx.core.http.HttpClientResponse;
-import io.vertx.core.http.HttpMethod;
-import io.vertx.core.json.JsonObject;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
-import io.vertx.ext.unit.Async;
-import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
+import static org.folio.logintest.TestUtil.doRequest;
+import static org.folio.logintest.UserMock.gollumId;
+import static org.folio.logintest.UserMock.sarumanId;
+
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
 import org.folio.logintest.TestUtil.WrappedResponse;
 import org.folio.rest.RestVerticle;
 import org.folio.rest.client.TenantClient;
 import org.folio.rest.impl.LoginAPI;
-import org.folio.rest.persist.Criteria.Criterion;
+import org.folio.rest.jaxrs.model.Parameter;
+import org.folio.rest.jaxrs.model.TenantAttributes;
 import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.tools.utils.NetworkUtils;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -31,24 +26,22 @@ import org.junit.Test;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 
-import java.net.HttpURLConnection;
-import java.util.Date;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
-
-import static org.folio.logintest.TestUtil.doRequest;
-import static org.folio.logintest.UserMock.bombadilId;
-import static org.folio.logintest.UserMock.gollumId;
-import static org.folio.logintest.UserMock.sarumanId;
-import org.folio.rest.jaxrs.model.Parameter;
-import org.folio.rest.jaxrs.model.TenantAttributes;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
 
 @RunWith(VertxUnitRunner.class)
 public class RestVerticleTest {
-
-  private static final String SUPPORTED_CONTENT_TYPE_JSON_DEF = "application/json";
 
   private JsonObject credsObject1 = new JsonObject()
     .put("username", "gollum")
@@ -77,13 +70,27 @@ public class RestVerticleTest {
     .put("password", "12345")
     .put("newPassword", "54321");
 
+  private JsonObject credsNoUsernameOrUserId = new JsonObject()
+      .put("password", "12345");
 
-  private static String postCredsRequest = "{\"username\": \"gollum\", \"userId\":\"" + gollumId + "\", \"password\":\"12345\"}";
-  private static String postCredsRequest2 = "{\"username\": \"gollum\", \"password\":\"12345\"}";
-  private static String postCredsRequest3 = "{\"username\": \"saruman\", \"userId\":\"" + sarumanId + "\", \"password\":\"12345\"}";
-  private static String postCredsRequest4 = "{\"username\": \"saruman\", \"password\":\"12345\"}";
-  private static String postCredsRequest5 = "{\"username\": \"bombadil\", \"userId\":\"" + bombadilId + "\", \"password\":\"12345\"}";
-  private static String postCredsRequest6 = "{\"username\": \"bombadil\", \"password\":\"12345\"}";
+  private JsonObject credsNoPassword = new JsonObject()
+      .put("username", "gollum");
+
+  private JsonObject credsElicitEmptyUserResp = new JsonObject()
+      .put("username", "mrunderhill")
+      .put("password", "54321");
+
+  private JsonObject credsElicitBadUserResp = new JsonObject()
+      .put("username", "gimli")
+      .put("password", "54321");
+
+  private JsonObject credsNonExistentUser = new JsonObject()
+      .put("username", "mickeymouse")
+      .put("password", "54321");
+
+  private JsonObject credsElicitMultiUserResp = new JsonObject()
+      .put("username", "gandalf")
+      .put("password", "54321");
 
   private static Vertx vertx;
   private static int port;
@@ -92,7 +99,6 @@ public class RestVerticleTest {
 
   private final Logger logger = LoggerFactory.getLogger(RestVerticleTest.class);
   private static String credentialsUrl;
-  private static String attemptsUrl;
   private static String loginUrl;
   private static String updateUrl;
   private static String okapiUrl;
@@ -108,7 +114,6 @@ public class RestVerticleTest {
     TenantClient tenantClient = new TenantClient("http://localhost:" + port, "diku", "diku");
     vertx = Vertx.vertx();
     credentialsUrl = "http://localhost:" + port + "/authn/credentials";
-    attemptsUrl = "http://localhost:" + port + "/authn/loginAttempts";
     loginUrl = "http://localhost:" + port + "/authn/login";
     updateUrl = "http://localhost:" + port + "/authn/update";
     okapiUrl = "http://localhost:" + mockPort;
@@ -210,6 +215,13 @@ public class RestVerticleTest {
         .compose(w -> testMockUser(context, "gollum", null))
         .compose(w -> testMockUser(context, null, gollumId))
         .compose(w -> failMockUser(context, "yomomma", null))
+        .compose(w -> doLoginNoToken(context, credsObject1))
+        .compose(w -> doLoginNoPassword(context, credsNoPassword))
+        .compose(w -> doLoginNoUsernameOrUserId(context, credsNoUsernameOrUserId))
+        .compose(w -> doLoginEmptyUserResponse(context, credsElicitEmptyUserResp))
+        .compose(w -> doLoginBadUserResponse(context, credsElicitBadUserResp))
+        .compose(w -> doLoginNonExistentUser(context, credsNonExistentUser))
+        .compose(w -> doLoginMultiUserRespose(context, credsElicitMultiUserResp))
         .compose(w -> doLogin(context, credsObject1))
         .compose(w -> doLogin(context, credsObject2))
         .compose(w -> postNewCredentials(context, credsObject3))
@@ -229,177 +241,6 @@ public class RestVerticleTest {
         async.complete();
       }
     });
-  }
-
-  //@Test
-  public void testGroup(TestContext context) {
-    String url = "http://localhost:" + port + "/authn/credentials";
-    try {
-      String credentialsId = null;
-
-      /**add creds */
-      CompletableFuture<Response> addPUCF = new CompletableFuture<>();
-      String addPUURL = url;
-      send(addPUURL, context, HttpMethod.POST, postCredsRequest,
-        SUPPORTED_CONTENT_TYPE_JSON_DEF, 201, new HTTPResponseHandler(addPUCF));
-      Response addPUResponse = addPUCF.get(5, TimeUnit.SECONDS);
-      credentialsId = addPUResponse.body.getString("id");
-      if (credentialsId == null) {
-        System.out.println("Null id status for body: " + addPUResponse.body.encode());
-      }
-      context.assertEquals(addPUResponse.code, HttpURLConnection.HTTP_CREATED);
-      System.out.println("Status - " + addPUResponse.code + " at " +
-        System.currentTimeMillis() + " for " + addPUURL);
-
-      /**add same creds again 422 */
-      CompletableFuture<Response> addPUCF2 = new CompletableFuture<>();
-      String addPUURL2 = url;
-      send(addPUURL2, context, HttpMethod.POST, postCredsRequest,
-        SUPPORTED_CONTENT_TYPE_JSON_DEF, 422, new HTTPResponseHandler(addPUCF2));
-      Response addPUResponse2 = addPUCF2.get(5, TimeUnit.SECONDS);
-      context.assertEquals(addPUResponse2.code, 422);
-      System.out.println(addPUResponse2.body +
-        "\nStatus - " + addPUResponse2.code + " at " + System.currentTimeMillis() + " for "
-        + addPUURL2);
-
-
-      /**try to GET the recently created creds 200 */
-      CompletableFuture<Response> addPUCF2_5 = new CompletableFuture<>();
-      String addPUURL2_5 = url + "/" + credentialsId;
-      send(addPUURL2_5, context, HttpMethod.GET, null,
-        SUPPORTED_CONTENT_TYPE_JSON_DEF, 200, new HTTPResponseHandler(addPUCF2_5));
-      Response addPUResponse2_5 = addPUCF2_5.get(5, TimeUnit.SECONDS);
-      context.assertEquals(addPUResponse2_5.code, 200);
-      System.out.println(addPUResponse2_5.body +
-        "\nStatus - " + addPUResponse2_5.code + " at " + System.currentTimeMillis() + " for "
-        + addPUURL2_5);
-
-      /**login with creds 201 */
-      CompletableFuture<Response> addPUCF3 = new CompletableFuture<>();
-      String addPUURL3 = "http://localhost:" + port + "/authn/login";
-      send(addPUURL3, context, HttpMethod.POST, postCredsRequest,
-        SUPPORTED_CONTENT_TYPE_JSON_DEF, 201, new HTTPResponseHandler(addPUCF3));
-      Response addPUResponse3 = addPUCF3.get(5, TimeUnit.SECONDS);
-      context.assertEquals(addPUResponse3.code, 201);
-      System.out.println(addPUResponse3.body +
-        "\nStatus - " + addPUResponse3.code + " at " + System.currentTimeMillis() + " for "
-        + addPUURL3);
-
-      /* test mock user*/
-      CompletableFuture<Response> addPUCF4 = new CompletableFuture<>();
-      String addPUURL4 = "http://localhost:" + mockPort + "/users?query=username==gollum";
-      send(addPUURL4, context, HttpMethod.GET, null,
-        SUPPORTED_CONTENT_TYPE_JSON_DEF, 200, new HTTPResponseHandler(addPUCF4));
-      Response addPUResponse4 = addPUCF4.get(5, TimeUnit.SECONDS);
-      context.assertEquals(addPUResponse4.code, 200);
-      System.out.println(addPUResponse4.body +
-        "\nStatus - " + addPUResponse4.code + " at " + System.currentTimeMillis() + " for "
-        + addPUURL4);
-
-
-      // test mock user 404
-      CompletableFuture<Response> addPUCF5 = new CompletableFuture<>();
-      String addPUURL5 = "http://localhost:" + mockPort + "/users?query=username==bilbo";
-      send(addPUURL5, context, HttpMethod.GET, null,
-        SUPPORTED_CONTENT_TYPE_JSON_DEF, 404, new HTTPResponseHandler(addPUCF5));
-      Response addPUResponse5 = addPUCF5.get(5, TimeUnit.SECONDS);
-      context.assertEquals(addPUResponse5.code, 404);
-      System.out.println(addPUResponse5.body +
-        "\nStatus - " + addPUResponse5.code + " at " + System.currentTimeMillis() + " for "
-        + addPUURL5);
-
-
-      /**login with creds, no userid supplied, 201 */
-      CompletableFuture<Response> addPUCF6 = new CompletableFuture<>();
-      String addPUURL6 = "http://localhost:" + port + "/authn/login";
-      send(addPUURL6, context, HttpMethod.POST, postCredsRequest2,
-        SUPPORTED_CONTENT_TYPE_JSON_DEF, 201, new HTTPResponseHandler(addPUCF6));
-      Response addPUResponse6 = addPUCF6.get(5, TimeUnit.SECONDS);
-      context.assertEquals(addPUResponse6.code, 201);
-      System.out.println(addPUResponse6.body +
-        "\nStatus - " + addPUResponse6.code + " at " + System.currentTimeMillis() + " for "
-        + addPUURL6);
-
-      /*add creds for inactive user */
-      CompletableFuture<Response> addPUCF7 = new CompletableFuture<>();
-      String addPUURL7 = url;
-      send(addPUURL7, context, HttpMethod.POST, postCredsRequest3,
-        SUPPORTED_CONTENT_TYPE_JSON_DEF, 201, new HTTPResponseHandler(addPUCF7));
-      Response addPUResponse7 = addPUCF7.get(5, TimeUnit.SECONDS);
-      credentialsId = addPUResponse7.body.getString("id");
-      context.assertEquals(addPUResponse7.code, HttpURLConnection.HTTP_CREATED);
-      System.out.println("Status - " + addPUResponse7.code + " at " +
-        System.currentTimeMillis() + " for " + addPUURL7);
-
-      /* try to login with inactive user */
-      CompletableFuture<Response> addPUCF8 = new CompletableFuture<>();
-      String addPUURL8 = "http://localhost:" + port + "/authn/login";
-      send(addPUURL8, context, HttpMethod.POST, postCredsRequest4,
-        SUPPORTED_CONTENT_TYPE_JSON_DEF, 400, new HTTPResponseHandler(addPUCF8));
-      Response addPUResponse8 = addPUCF8.get(5, TimeUnit.SECONDS);
-      context.assertEquals(addPUResponse8.code, 400);
-      System.out.println(addPUResponse8.body +
-        "\nStatus - " + addPUResponse8.code + " at " + System.currentTimeMillis() + " for "
-        + addPUURL8);
-
-      /*add creds for slow lookup user */
-      CompletableFuture<Response> addPUCF9 = new CompletableFuture<>();
-      String addPUURL9 = url;
-      send(addPUURL9, context, HttpMethod.POST, postCredsRequest5,
-        SUPPORTED_CONTENT_TYPE_JSON_DEF, 201, new HTTPResponseHandler(addPUCF9));
-      Response addPUResponse9 = addPUCF9.get(5, TimeUnit.SECONDS);
-      credentialsId = addPUResponse9.body.getString("id");
-      context.assertEquals(addPUResponse9.code, HttpURLConnection.HTTP_CREATED);
-      System.out.println("Status - " + addPUResponse9.code + " at " +
-        System.currentTimeMillis() + " for " + addPUURL9);
-
-      /* try to login with slow lookup user */
-      CompletableFuture<Response> addPUCF10 = new CompletableFuture<>();
-      String addPUURL10 = "http://localhost:" + port + "/authn/login";
-      send(addPUURL10, context, HttpMethod.POST, postCredsRequest6,
-        SUPPORTED_CONTENT_TYPE_JSON_DEF, 200, new HTTPResponseHandler(addPUCF10));
-      Response addPUResponse10 = addPUCF10.get(5, TimeUnit.SECONDS);
-      context.assertEquals(addPUResponse10.code, 201);
-      System.out.println(addPUResponse10.body +
-        "\nStatus - " + addPUResponse10.code + " at " + System.currentTimeMillis() + " for "
-        + addPUURL10);
-
-
-    } catch (Exception e) {
-      e.printStackTrace();
-      context.fail(e.getMessage());
-    }
-  }
-
-  private void send(String url, TestContext context, HttpMethod method, String content,
-                    String contentType, int errorCode, Handler<HttpClientResponse> handler) {
-    HttpClient client = vertx.createHttpClient();
-    HttpClientRequest request;
-    if (content == null) {
-      content = "";
-    }
-    Buffer buffer = Buffer.buffer(content);
-
-    if (method == HttpMethod.POST) {
-      request = client.postAbs(url);
-    } else if (method == HttpMethod.DELETE) {
-      request = client.deleteAbs(url);
-    } else if (method == HttpMethod.GET) {
-      request = client.getAbs(url);
-    } else {
-      request = client.putAbs(url);
-    }
-    request.exceptionHandler(error -> {
-      context.fail(error.getMessage());
-    })
-      .handler(handler);
-    request.putHeader("Authorization", "diku");
-    request.putHeader("x-okapi-tenant", "diku");
-    request.putHeader("Accept", "application/json,text/plain");
-    request.putHeader("Content-type", contentType);
-    request.putHeader("X-Okapi-Url", "http://localhost:" + mockPort);
-    request.putHeader("X-Okapi-Token", "dummytoken");
-    request.end(buffer);
   }
 
   class HTTPResponseHandler implements Handler<HttpClientResponse> {
@@ -446,10 +287,6 @@ public class RestVerticleTest {
     JsonObject body;
   }
 
-  private boolean isSizeMatch(Response r, int size) {
-    return r.body.getInteger("total_records") == size;
-  }
-
   private Future<WrappedResponse> postNewCredentials(TestContext context,
                                                      JsonObject newCredentials) {
     return doRequest(vertx, credentialsUrl, HttpMethod.POST, null, newCredentials.encode(),
@@ -492,6 +329,45 @@ public class RestVerticleTest {
   private Future<WrappedResponse> doLogin(TestContext context, JsonObject loginCredentials) {
     return doRequest(vertx, loginUrl, HttpMethod.POST, headers, loginCredentials.encode(),
       201, "Login with created credentials");
+  }
+
+  private Future<WrappedResponse> doLoginNoUsernameOrUserId(TestContext context, JsonObject loginCredentials) {
+    return doRequest(vertx, loginUrl, HttpMethod.POST, headers, loginCredentials.encode(),
+      400, "You must provide a username or userId");
+  }
+
+  private Future<WrappedResponse> doLoginNoPassword(TestContext context, JsonObject loginCredentials) {
+    return doRequest(vertx, loginUrl, HttpMethod.POST, headers, loginCredentials.encode(),
+      400, "You must provide a password");
+  }
+
+  private Future<WrappedResponse> doLoginNoToken(TestContext context, JsonObject loginCredentials) {
+    MultiMap headersNoToken = MultiMap.caseInsensitiveMultiMap();
+    headersNoToken.addAll(headers);
+    headersNoToken.remove(RestVerticle.OKAPI_HEADER_TOKEN);
+
+    return doRequest(vertx, loginUrl, HttpMethod.POST, headersNoToken, loginCredentials.encode(),
+      400, "Missing Okapi token header");
+  }
+
+  private Future<WrappedResponse> doLoginBadUserResponse(TestContext context, JsonObject loginCredentials) {
+    return doRequest(vertx, loginUrl, HttpMethod.POST, headers, loginCredentials.encode(),
+      422, "Error verifying user existence: Error, missing field(s) 'totalRecords' and/or 'users' in user response object");
+  }
+
+  private Future<WrappedResponse> doLoginMultiUserRespose(TestContext context, JsonObject loginCredentials) {
+    return doRequest(vertx, loginUrl, HttpMethod.POST, headers, loginCredentials.encode(),
+      422, "Error verifying user existence: Error, missing field(s) 'totalRecords' and/or 'users' in user response object");
+  }
+
+  private Future<WrappedResponse> doLoginNonExistentUser(TestContext context, JsonObject loginCredentials) {
+    return doRequest(vertx, loginUrl, HttpMethod.POST, headers, loginCredentials.encode(),
+      422, "Error verifying user existence: Error, missing field(s) 'totalRecords' and/or 'users' in user response object");
+  }
+
+  private Future<WrappedResponse> doLoginEmptyUserResponse(TestContext context, JsonObject loginCredentials) {
+    return doRequest(vertx, loginUrl, HttpMethod.POST, headers, loginCredentials.encode(),
+      422, "Error verifying user existence: Bad results from username");
   }
 
   private Future<WrappedResponse> doInactiveLogin(TestContext context, JsonObject loginCredentials) {

--- a/src/test/java/org/folio/logintest/RestVerticleTest.java
+++ b/src/test/java/org/folio/logintest/RestVerticleTest.java
@@ -3,9 +3,9 @@ package org.folio.logintest;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.CaseInsensitiveHeaders;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpClientResponse;
@@ -88,7 +88,7 @@ public class RestVerticleTest {
   private static Vertx vertx;
   private static int port;
   private static int mockPort;
-  private static CaseInsensitiveHeaders headers;
+  private static MultiMap headers;
 
   private final Logger logger = LoggerFactory.getLogger(RestVerticleTest.class);
   private static String credentialsUrl;
@@ -113,7 +113,7 @@ public class RestVerticleTest {
     updateUrl = "http://localhost:" + port + "/authn/update";
     okapiUrl = "http://localhost:" + mockPort;
 
-    headers = new CaseInsensitiveHeaders();
+    headers = MultiMap.caseInsensitiveMultiMap();
     headers.add(RestVerticle.OKAPI_HEADER_TOKEN, "dummytoken");
     headers.add(LoginAPI.OKAPI_URL_HEADER, okapiUrl);
     headers.add(LoginAPI.OKAPI_REQUEST_TIMESTAMP_HEADER, String.valueOf(new Date().getTime()));
@@ -221,7 +221,7 @@ public class RestVerticleTest {
         .compose(w -> doLogin(context, credsObject5))
         .compose(w -> doBadCredentialsUpdatePassword(context, credsObject6))
         .compose(w -> doBadInputUpdatePassword(context, credsObject4));
-    chainedFuture.setHandler(chainedRes -> {
+    chainedFuture.onComplete(chainedRes -> {
       if (chainedRes.failed()) {
         logger.error("Test failed: " + chainedRes.cause().getLocalizedMessage());
         context.fail(chainedRes.cause());
@@ -238,7 +238,7 @@ public class RestVerticleTest {
       String credentialsId = null;
 
       /**add creds */
-      CompletableFuture<Response> addPUCF = new CompletableFuture();
+      CompletableFuture<Response> addPUCF = new CompletableFuture<>();
       String addPUURL = url;
       send(addPUURL, context, HttpMethod.POST, postCredsRequest,
         SUPPORTED_CONTENT_TYPE_JSON_DEF, 201, new HTTPResponseHandler(addPUCF));
@@ -252,7 +252,7 @@ public class RestVerticleTest {
         System.currentTimeMillis() + " for " + addPUURL);
 
       /**add same creds again 422 */
-      CompletableFuture<Response> addPUCF2 = new CompletableFuture();
+      CompletableFuture<Response> addPUCF2 = new CompletableFuture<>();
       String addPUURL2 = url;
       send(addPUURL2, context, HttpMethod.POST, postCredsRequest,
         SUPPORTED_CONTENT_TYPE_JSON_DEF, 422, new HTTPResponseHandler(addPUCF2));
@@ -264,7 +264,7 @@ public class RestVerticleTest {
 
 
       /**try to GET the recently created creds 200 */
-      CompletableFuture<Response> addPUCF2_5 = new CompletableFuture();
+      CompletableFuture<Response> addPUCF2_5 = new CompletableFuture<>();
       String addPUURL2_5 = url + "/" + credentialsId;
       send(addPUURL2_5, context, HttpMethod.GET, null,
         SUPPORTED_CONTENT_TYPE_JSON_DEF, 200, new HTTPResponseHandler(addPUCF2_5));
@@ -275,7 +275,7 @@ public class RestVerticleTest {
         + addPUURL2_5);
 
       /**login with creds 201 */
-      CompletableFuture<Response> addPUCF3 = new CompletableFuture();
+      CompletableFuture<Response> addPUCF3 = new CompletableFuture<>();
       String addPUURL3 = "http://localhost:" + port + "/authn/login";
       send(addPUURL3, context, HttpMethod.POST, postCredsRequest,
         SUPPORTED_CONTENT_TYPE_JSON_DEF, 201, new HTTPResponseHandler(addPUCF3));
@@ -286,7 +286,7 @@ public class RestVerticleTest {
         + addPUURL3);
 
       /* test mock user*/
-      CompletableFuture<Response> addPUCF4 = new CompletableFuture();
+      CompletableFuture<Response> addPUCF4 = new CompletableFuture<>();
       String addPUURL4 = "http://localhost:" + mockPort + "/users?query=username==gollum";
       send(addPUURL4, context, HttpMethod.GET, null,
         SUPPORTED_CONTENT_TYPE_JSON_DEF, 200, new HTTPResponseHandler(addPUCF4));
@@ -298,7 +298,7 @@ public class RestVerticleTest {
 
 
       // test mock user 404
-      CompletableFuture<Response> addPUCF5 = new CompletableFuture();
+      CompletableFuture<Response> addPUCF5 = new CompletableFuture<>();
       String addPUURL5 = "http://localhost:" + mockPort + "/users?query=username==bilbo";
       send(addPUURL5, context, HttpMethod.GET, null,
         SUPPORTED_CONTENT_TYPE_JSON_DEF, 404, new HTTPResponseHandler(addPUCF5));
@@ -310,7 +310,7 @@ public class RestVerticleTest {
 
 
       /**login with creds, no userid supplied, 201 */
-      CompletableFuture<Response> addPUCF6 = new CompletableFuture();
+      CompletableFuture<Response> addPUCF6 = new CompletableFuture<>();
       String addPUURL6 = "http://localhost:" + port + "/authn/login";
       send(addPUURL6, context, HttpMethod.POST, postCredsRequest2,
         SUPPORTED_CONTENT_TYPE_JSON_DEF, 201, new HTTPResponseHandler(addPUCF6));
@@ -321,7 +321,7 @@ public class RestVerticleTest {
         + addPUURL6);
 
       /*add creds for inactive user */
-      CompletableFuture<Response> addPUCF7 = new CompletableFuture();
+      CompletableFuture<Response> addPUCF7 = new CompletableFuture<>();
       String addPUURL7 = url;
       send(addPUURL7, context, HttpMethod.POST, postCredsRequest3,
         SUPPORTED_CONTENT_TYPE_JSON_DEF, 201, new HTTPResponseHandler(addPUCF7));
@@ -332,7 +332,7 @@ public class RestVerticleTest {
         System.currentTimeMillis() + " for " + addPUURL7);
 
       /* try to login with inactive user */
-      CompletableFuture<Response> addPUCF8 = new CompletableFuture();
+      CompletableFuture<Response> addPUCF8 = new CompletableFuture<>();
       String addPUURL8 = "http://localhost:" + port + "/authn/login";
       send(addPUURL8, context, HttpMethod.POST, postCredsRequest4,
         SUPPORTED_CONTENT_TYPE_JSON_DEF, 400, new HTTPResponseHandler(addPUCF8));
@@ -343,7 +343,7 @@ public class RestVerticleTest {
         + addPUURL8);
 
       /*add creds for slow lookup user */
-      CompletableFuture<Response> addPUCF9 = new CompletableFuture();
+      CompletableFuture<Response> addPUCF9 = new CompletableFuture<>();
       String addPUURL9 = url;
       send(addPUURL9, context, HttpMethod.POST, postCredsRequest5,
         SUPPORTED_CONTENT_TYPE_JSON_DEF, 201, new HTTPResponseHandler(addPUCF9));
@@ -354,7 +354,7 @@ public class RestVerticleTest {
         System.currentTimeMillis() + " for " + addPUURL9);
 
       /* try to login with slow lookup user */
-      CompletableFuture<Response> addPUCF10 = new CompletableFuture();
+      CompletableFuture<Response> addPUCF10 = new CompletableFuture<>();
       String addPUURL10 = "http://localhost:" + port + "/authn/login";
       send(addPUURL10, context, HttpMethod.POST, postCredsRequest6,
         SUPPORTED_CONTENT_TYPE_JSON_DEF, 200, new HTTPResponseHandler(addPUCF10));

--- a/src/test/java/org/folio/logintest/TestUtil.java
+++ b/src/test/java/org/folio/logintest/TestUtil.java
@@ -66,7 +66,7 @@ public class TestUtil {
           HttpMethod method, MultiMap headers, String payload,
           Integer expectedCode, String explanation) {
     Promise<WrappedResponse> promise = Promise.promise();
-    WebClient client = WebClientFactory.getWebClient();
+    WebClient client = WebClientFactory.getWebClient(vertx);
     HttpRequest<Buffer> request = client.requestAbs(method, url);
     //Add standard headers
     request.putHeader("X-Okapi-Tenant", "diku")

--- a/src/test/java/org/folio/logintest/UpdateCredentialsHistoryTest.java
+++ b/src/test/java/org/folio/logintest/UpdateCredentialsHistoryTest.java
@@ -220,8 +220,13 @@ public class UpdateCredentialsHistoryTest {
     Promise<Void> promise = Promise.promise();
     DeploymentOptions options = new DeploymentOptions().setConfig(
       new JsonObject().put("port", mockPort));
-    vertx.deployVerticle(UserMock.class, options, done -> promise.complete());
-
+    vertx.deployVerticle(UserMock.class, options, reply -> {
+      if (reply.failed()) {
+        promise.fail(reply.cause());
+      } else {
+        promise.complete();
+      }
+    });
     return promise.future();
   }
 
@@ -229,8 +234,13 @@ public class UpdateCredentialsHistoryTest {
     Promise<Void> promise = Promise.promise();
     DeploymentOptions options = new DeploymentOptions().setConfig(
       new JsonObject().put("http.port", port));
-    vertx.deployVerticle(RestVerticle.class, options, done -> promise.complete());
-
+    vertx.deployVerticle(RestVerticle.class, options, reply -> {
+      if (reply.failed()) {
+        promise.fail(reply.cause());
+      } else {
+        promise.complete();
+      }
+    });
     return promise.future();
   }
 
@@ -244,20 +254,37 @@ public class UpdateCredentialsHistoryTest {
       .withSalt(salt)
       .withHash(authUtil.calculateHash(INITIAL_PASSWORD, salt))
       .withUserId(gollumId);
-    pgClient.save(TABLE_NAME_CRED, id, cred, done -> promise.complete());
-
+    pgClient.save(TABLE_NAME_CRED, id, cred, reply -> {
+      if (reply.failed()) {
+        promise.fail(reply.cause());
+      } else {
+        promise.complete();
+      }
+    });
     return promise.future();
   }
 
   private Future<Void> clearCredentialsHistoryTable() {
     Promise<Void> promise = Promise.promise();
-    pgClient.delete(TABLE_NAME_CRED_HIST, new Criterion(userIdCrit), done -> promise.complete());
+    pgClient.delete(TABLE_NAME_CRED_HIST, new Criterion(userIdCrit), reply -> {
+      if (reply.failed()) {
+        promise.fail(reply.cause());
+      } else {
+        promise.complete();
+      }
+    });
     return promise.future();
   }
 
   private Future<Void> clearCredentialsTable() {
     Promise<Void> promise = Promise.promise();
-    pgClient.delete(TABLE_NAME_CRED, new Criterion(userIdCrit), done -> promise.complete());
+    pgClient.delete(TABLE_NAME_CRED, new Criterion(userIdCrit), reply -> {
+      if (reply.failed()) {
+        promise.fail(reply.cause());
+      } else {
+        promise.complete();
+      }
+    });
     return promise.future();
   }
 

--- a/src/test/java/org/folio/logintest/UserMock.java
+++ b/src/test/java/org/folio/logintest/UserMock.java
@@ -6,6 +6,8 @@ import static org.folio.util.LoginAttemptsHelper.LOGIN_ATTEMPTS_TIMEOUT_CODE;
 
 import java.util.UUID;
 
+import org.drools.core.spi.Accumulator.SafeAccumulator;
+
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Promise;
 import io.vertx.core.http.HttpServer;
@@ -41,7 +43,7 @@ public class UserMock extends AbstractVerticle {
     HttpServer server = vertx.createHttpServer();
 
     router.route("/users").handler(this::handleUsers);
-    router.putWithRegex("/users/.*").handler(this::handleUserPut);
+    router.put("/users/:id").handler(this::handleUserPut);
     router.route("/token").handler(this::handleToken);
     router.route("/refreshtoken").handler(this::handleRefreshToken);
     router.route("/configurations/entries").handler(this::handleConfig);
@@ -116,6 +118,18 @@ public class UserMock extends AbstractVerticle {
                   .put("id", UUID.randomUUID().toString())
                   .put("active", false)))
             .put("totalRecords", 2);
+          context.response()
+            .setStatusCode(200)
+            .end(responseOb.encode());
+          break;
+        case "username==strider":
+          userOb = new JsonObject()
+            .put("username", "strider")
+            .put("active", true);
+          responseOb = new JsonObject()
+            .put("users", new JsonArray()
+              .add(userOb))
+            .put("totalRecords", 1);
           context.response()
             .setStatusCode(200)
             .end(responseOb.encode());
@@ -233,10 +247,17 @@ public class UserMock extends AbstractVerticle {
   }
 
   private void handleUserPut(RoutingContext context) {
-    admin.put("active", false);
-    context.response()
-      .setStatusCode(204)
-      .end();
+    String id = context.request().getParam("id");
+    if(id.equals(adminId)) {
+      admin.put("active", false);
+      context.response()
+        .setStatusCode(204)
+        .end();
+    } else {
+      context.response()
+        .setStatusCode(204)
+        .end();
+    }
   }
 }
 

--- a/src/test/java/org/folio/logintest/UserMock.java
+++ b/src/test/java/org/folio/logintest/UserMock.java
@@ -4,6 +4,8 @@ import static java.lang.Thread.sleep;
 import static org.folio.util.LoginAttemptsHelper.LOGIN_ATTEMPTS_CODE;
 import static org.folio.util.LoginAttemptsHelper.LOGIN_ATTEMPTS_TIMEOUT_CODE;
 
+import java.util.UUID;
+
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Promise;
 import io.vertx.core.http.HttpServer;
@@ -20,6 +22,7 @@ public class UserMock extends AbstractVerticle {
   public static final String gollumId = "bc6e4932-6415-40e2-ac1e-67ecdd665366";
   public static final String bombadilId = "35bbcda7-866a-4231-b478-59b9dd2eb3ee";
   public static final String sarumanId = "340bafb8-ea74-4f51-be8c-ec6493fd517e";
+  public static final String gimliId = "ade0c47f-4c86-46e1-8932-0991322799c1";
   private static final String adminId = "8bd684c1-bbc3-4cf1-bcf4-8013d02a94ce";
 
   private JsonObject admin = new JsonObject()
@@ -85,7 +88,37 @@ public class UserMock extends AbstractVerticle {
           context.response()
             .setStatusCode(200)
             .end(responseOb.encode());
-
+          break;
+        case "username==gimli":
+          userOb = new JsonObject();
+          context.response()
+            .setStatusCode(200)
+            .end(userOb.encode());
+          break;
+        case "username==mrunderhill":
+          userOb = new JsonObject();
+          responseOb = new JsonObject()
+            .put("users", new JsonArray()
+              .add(userOb))
+            .put("totalRecords", 0);
+          context.response()
+            .setStatusCode(200)
+            .end(responseOb.encode());
+        case "username==gandalf":
+          responseOb = new JsonObject()
+            .put("users", new JsonArray()
+              .add(new JsonObject()
+                  .put("username", "gandalf")
+                  .put("id", UUID.randomUUID().toString())
+                  .put("active", true))
+              .add(new JsonObject()
+                  .put("username", "gandalf")
+                  .put("id", UUID.randomUUID().toString())
+                  .put("active", false)))
+            .put("totalRecords", 2);
+          context.response()
+            .setStatusCode(200)
+            .end(responseOb.encode());
           break;
         case "username==saruman":
           userOb = new JsonObject()

--- a/src/test/java/org/folio/logintest/UserMock.java
+++ b/src/test/java/org/folio/logintest/UserMock.java
@@ -1,16 +1,16 @@
 package org.folio.logintest;
 
+import static java.lang.Thread.sleep;
+import static org.folio.util.LoginAttemptsHelper.LOGIN_ATTEMPTS_CODE;
+import static org.folio.util.LoginAttemptsHelper.LOGIN_ATTEMPTS_TIMEOUT_CODE;
+
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
-
-import static java.lang.Thread.sleep;
-import static org.folio.util.LoginAttemptsHelper.LOGIN_ATTEMPTS_CODE;
-import static org.folio.util.LoginAttemptsHelper.LOGIN_ATTEMPTS_TIMEOUT_CODE;
 
 /**
  * @author kurt
@@ -31,23 +31,23 @@ public class UserMock extends AbstractVerticle {
       .add(admin))
     .put("totalRecords", 1);
 
-  public void start(Future<Void> future) {
+  public void start(Promise<Void> promise) {
     final int port = context.config().getInteger("port");
 
     Router router = Router.router(vertx);
     HttpServer server = vertx.createHttpServer();
 
     router.route("/users").handler(this::handleUsers);
-    router.put("/users/" + adminId).handler(this::handleUserPut);
+    router.putWithRegex("/users/.*").handler(this::handleUserPut);
     router.route("/token").handler(this::handleToken);
     router.route("/refreshtoken").handler(this::handleRefreshToken);
     router.route("/configurations/entries").handler(this::handleConfig);
     System.out.println("Running UserMock on port " + port);
-    server.requestHandler(router::accept).listen(port, result -> {
+    server.requestHandler(router::handle).listen(port, result -> {
       if (result.failed()) {
-        future.fail(result.cause());
+        promise.fail(result.cause());
       } else {
-        future.complete();
+        promise.complete();
       }
     });
   }

--- a/src/test/java/org/folio/logintest/UserMock.java
+++ b/src/test/java/org/folio/logintest/UserMock.java
@@ -108,6 +108,7 @@ public class UserMock extends AbstractVerticle {
           context.response()
             .setStatusCode(200)
             .end(responseOb.encode());
+          break;
         case "username==gandalf":
           responseOb = new JsonObject()
             .put("users", new JsonArray()

--- a/src/test/java/org/folio/util/WebClientFactoryTest.java
+++ b/src/test/java/org/folio/util/WebClientFactoryTest.java
@@ -1,0 +1,36 @@
+package org.folio.util;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class WebClientFactoryTest {
+
+  public class MyVerticle extends AbstractVerticle {
+    @Override
+    public void start(Future<Void> startFuture) {
+      Thread verticleThread = Thread.currentThread();
+      WebClientFactory.getWebClient().getAbs("http://invalid/").send(get -> {
+        Context clientContext = Vertx.currentContext();
+        if (clientContext != context) {
+          startFuture.fail("Context mismatch:\n" + context + " !=\n" + clientContext
+              + "\n Thread mismatch:\n" + verticleThread + " != \n" + Thread.currentThread());
+        }
+      });
+    }
+  }
+
+  @Test
+  public void verticles(TestContext testContext) {
+    Vertx vertx = Vertx.vertx();
+    Vertx.vertx().deployVerticle(new MyVerticle(), testContext.asyncAssertSuccess(verticle1 -> {
+      vertx.deployVerticle(new MyVerticle(), testContext.asyncAssertSuccess());
+    }));
+  }
+}

--- a/src/test/java/org/folio/util/WebClientFactoryTest.java
+++ b/src/test/java/org/folio/util/WebClientFactoryTest.java
@@ -1,26 +1,37 @@
 package org.folio.util;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Context;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import io.vertx.ext.web.client.WebClient;
 
 @RunWith(VertxUnitRunner.class)
 public class WebClientFactoryTest {
 
   public class MyVerticle extends AbstractVerticle {
     @Override
-    public void start(Future<Void> startFuture) {
+    public void start(Promise<Void> startFuture) {
+      WebClientFactory.init(vertx);
+      WebClient client = WebClientFactory.getWebClient(vertx);
       Thread verticleThread = Thread.currentThread();
-      WebClientFactory.getWebClient().getAbs("http://invalid/").send(get -> {
+      client.getAbs("http://invalid/").send(get -> {
+        WebClient client2 = WebClientFactory.getWebClient(vertx);
+        if(client != client2) {
+          startFuture.fail("Client mismatch: " + client.hashCode() + " != " + client2.hashCode());
+        }
         Context clientContext = Vertx.currentContext();
         if (clientContext != context) {
           startFuture.fail("Context mismatch:\n" + context + " !=\n" + clientContext
               + "\n Thread mismatch:\n" + verticleThread + " != \n" + Thread.currentThread());
+        } else {
+          startFuture.complete();
+          System.out.println(Thread.activeCount());
         }
       });
     }


### PR DESCRIPTION
## Purpose
Upgrade to RMB 30.0.0 in preparation for the Q2/Goldenrod release.

See [MODLOGIN-127](https://issues.folio.org/browse/MODLOGIN-127)

## Approach
* CompletableFuture -> Promise
* HttpClient -> WebClient
  - new dependency in pom.xml
* PostgresClient changes
* Unit tests were updated, including one bug in the mock server (only handing PUT /users/<id> for a single particular userId.  
* Move away from storing/retrieving the HttpClient on the VertxContext.  Instead use a Bill Pugh singleton.  Creating and putting a client on the VertxContext in InitAPI and then accessing it later on was unreliable - not sure what happened as it appeared to work before.  I think this is straightforward and reliable though.

## Links
* [RMB Upgrade Guide](https://github.com/folio-org/raml-module-builder/blob/v30.0.0/doc/upgrading.md#version-300)
* [Vertx Deprecations and Breaking Changes](https://github.com/vert-x3/wiki/wiki/4.0.0-Deprecations-and-breaking-changes)