### PR TITLE
MODLOGIN-131 - Handle missing credentials gracefully

### DIFF
--- a/src/test/java/org/folio/logintest/PasswordRepeatabilityValidationTest.java
+++ b/src/test/java/org/folio/logintest/PasswordRepeatabilityValidationTest.java
@@ -165,6 +165,21 @@ public class PasswordRepeatabilityValidationTest {
       .body(RESULT_JSON_PATH, is(INVALID));
   }
 
+  @Test
+  public void testNoCredentialsFound() {
+    String userId = UUID.randomUUID().toString();
+    RestAssured.given()
+      .spec(spec)
+      .header(RestVerticle.OKAPI_USERID_HEADER, userId)
+      .body(buildPasswordEntity(CURRENT_PASSWORD, userId))
+      .when()
+      .post(PASSWORD_REAPITABILITY_VALIDATION_PATH)
+      .then()
+      .log().all()
+      .statusCode(200)
+      .body(RESULT_JSON_PATH, is(VALID));
+  }
+
   private static Future<Void> fillInCredentialsHistory() {
     Promise<CompositeFuture> promise = Promise.promise();
 
@@ -224,8 +239,12 @@ public class PasswordRepeatabilityValidationTest {
   }
 
   private Password buildPasswordEntity(String password) {
+    return buildPasswordEntity(password, USER_ID);
+  }
+
+  private Password buildPasswordEntity(String password, String userId) {
     return new Password()
       .withPassword(password)
-      .withUserId(USER_ID);
+      .withUserId(userId);
   }
 }


### PR DESCRIPTION
## Purpose
If a credential record is not found during a call to POST /authn/password-repeatable, the PasswordStorageServiceImpl fails the promise/future returned by getCredsById(...) causing a 500 Internal Server Error to be returned w/o any context.

The error handling should be adjusted so that when a credentials record doesn't exist, a response is sent indicating that the password is not a repeat.