### PR TITLE
MODLOGIN-129 - Disallow empty string passwords

### DIFF
--- a/src/main/java/org/folio/rest/impl/LoginAPI.java
+++ b/src/main/java/org/folio/rest/impl/LoginAPI.java
@@ -599,11 +599,11 @@ public class LoginAPI implements Authn {
           userVerifyFuture = lookupUser(entity.getUsername(), null,
             tenantId, okapiURL, requestToken);
         }
-        if (entity.getPassword() == null) {
+        if (entity.getPassword() == null || entity.getPassword().isEmpty()) {
           asyncResultHandler.handle(Future.succeededFuture(
             PostAuthnCredentialsResponse.respond422WithApplicationJson(
               ValidationHelper.createValidationErrorMessage(
-                CREDENTIAL_USERID_FIELD, entity.getUserId(), "Password is missing"))));
+                CREDENTIAL_USERID_FIELD, entity.getUserId(), "Password is missing or empty"))));
           return;
         }
         userVerifyFuture.onComplete(verifyRes -> {
@@ -1163,9 +1163,9 @@ public class LoginAPI implements Authn {
               .respond400WithTextPlain("You must provide a username or userId")));
           return;
         }
-        if(entity.getNewPassword() == null) {
+        if(entity.getNewPassword() == null || entity.getNewPassword().isEmpty()) {
           asyncResultHandler.handle(Future.succeededFuture(PostAuthnLoginResponse
-              .respond400WithTextPlain("You must provide a new password")));
+              .respond400WithTextPlain("You must provide a new password that isn't empty")));
           return;
         }
         if(entity.getUserId() != null && !requireActiveUser) {

--- a/src/test/java/org/folio/logintest/RestVerticleTest.java
+++ b/src/test/java/org/folio/logintest/RestVerticleTest.java
@@ -96,6 +96,16 @@ public class RestVerticleTest {
       .put("username", "strider")
       .put("password", "54321");
 
+  private JsonObject credsEmptyStringPassword = new JsonObject()
+      .put("username", "saruman")
+      .put("userId", sarumanId)
+      .put("password", "");
+
+  private JsonObject newCredsEmptyPassword = new JsonObject()
+      .put("username", "gollum")
+      .put("password", "12345")
+      .put("newPassword", "");
+
   private static Vertx vertx;
   private static int port;
   private static int mockPort;
@@ -229,7 +239,9 @@ public class RestVerticleTest {
         .compose(w -> doLoginNoUserId(context, credsUserWithNoId))
         .compose(w -> doLogin(context, credsObject1))
         .compose(w -> doLogin(context, credsObject2))
+        .compose(w -> postNewCredentialsWithEmptyStringPassword(context, credsEmptyStringPassword))
         .compose(w -> postNewCredentials(context, credsObject3))
+        .compose(w -> doUpdatePasswordWithEmptyString(context, newCredsEmptyPassword))
         .compose(w -> doInactiveLogin(context, credsObject3))
         .compose(w -> doBadPasswordLogin(context, credsObject4))
         .compose(w -> doBadPasswordLogin(context, credsObject5))
@@ -302,6 +314,11 @@ public class RestVerticleTest {
                                                            JsonObject newCredentials) {
     return doRequest(vertx, credentialsUrl, HttpMethod.POST, null, newCredentials.encode(),
       422, "Try to add a duplicate credential object");
+  }
+
+  private Future<WrappedResponse> postNewCredentialsWithEmptyStringPassword(TestContext context, JsonObject updateCredentials) {
+    return doRequest(vertx, credentialsUrl, HttpMethod.POST, headers, updateCredentials.encode(),
+      422, "Attempt to create credentials with an empty string password");
   }
 
   private Future<WrappedResponse> getCredentials(TestContext context, String credsId) {
@@ -403,6 +420,11 @@ public class RestVerticleTest {
   private Future<WrappedResponse> doBadInputUpdatePassword(TestContext context, JsonObject updateCredentials) {
     return doRequest(vertx, updateUrl, HttpMethod.POST, headers, updateCredentials.encode(),
       400, "Attempt to update password with bad data");
+  }
+
+  private Future<WrappedResponse> doUpdatePasswordWithEmptyString(TestContext context, JsonObject updateCredentials) {
+    return doRequest(vertx, updateUrl, HttpMethod.POST, headers, updateCredentials.encode(),
+      400, "Attempt to update password with an empty string password");
   }
 }
 


### PR DESCRIPTION
## Purpose
A POST request to authn/credentials allows for passwords consisting of an empty string. This should not be permissible.

Also includes prevention of setting "" passwords via the POST /authn/update endpoint.

See [MODLOGIN-129](https://issues.folio.org/browse/MODLOGIN-129)