### PR TITLE
MODLOGIN-126 - Release  v7.0.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,20 @@
+## 2020-06-10 v7.0.0
+The main focus of this release is to address several security issues.
+
+[Full Changelog](https://github.com/folio-org/mod-login/compare/v6.2.0...v7.0.0)
+
+### Stories
+* [MODLOGIN-127](https://issues.folio.org/browse/MODLOGIN-127) - Upgrade to RMB 30.0.0
+* [MODLOGIN-130](https://issues.folio.org/browse/MODLOGIN-130) - Provide permissionsRequired property
+* [MODLOGIN-132](https://issues.folio.org/browse/MODLOGIN-132) - Do not return credential hash/salt when posting credentials
+* [MODLOGIN-133](https://issues.folio.org/browse/MODLOGIN-133) - Remove PUT /authn/credentials/{id}
+* [MODLOGIN-134](https://issues.folio.org/browse/MODLOGIN-134) - Refactor DELETE /authn/credentials/{id}
+
+### Bugs
+* [MODLOGIN-128](https://issues.folio.org/browse/MODLOGIN-128) - It is possible to fetch password hashes for all users
+* [MODLOGIN-129](https://issues.folio.org/browse/MODLOGIN-129) - POST to /authn/credentials accepts empty string for password
+* [MODLOGIN-131](https://issues.folio.org/browse/MODLOGIN-131) - Reset password fails if credentials record does not already exist
+
 ## 2019-12-04 v6.2.0
  * MODLOGIN-122 Upgrade to RMB 29
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@ The main focus of this release is to address several security issues.
 * [MODLOGIN-134](https://issues.folio.org/browse/MODLOGIN-134) - Refactor DELETE /authn/credentials/{id}
 
 ### Bugs
+* [MODLOGIN-24](https://issues.folio.org/brows/MODLOGIN-24) - POST /authn/credentials returns 500 when password is missing
 * [MODLOGIN-128](https://issues.folio.org/browse/MODLOGIN-128) - It is possible to fetch password hashes for all users
 * [MODLOGIN-129](https://issues.folio.org/browse/MODLOGIN-129) - POST to /authn/credentials accepts empty string for password
 * [MODLOGIN-131](https://issues.folio.org/browse/MODLOGIN-131) - Reset password fails if credentials record does not already exist

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-login</artifactId>
-  <version>7.0.0</version>
+  <version>7.1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -451,7 +451,7 @@
     <url>https://github.com/folio-org/${project.artifactId}</url>
     <connection>scm:git:git://github.com/folio-org/${project.artifactId}.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/${project.artifactId}.git</developerConnection>
-    <tag>v7.0.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-login</artifactId>
-  <version>6.3.0-SNAPSHOT</version>
+  <version>7.0.0</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -451,7 +451,7 @@
     <url>https://github.com/folio-org/${project.artifactId}</url>
     <connection>scm:git:git://github.com/folio-org/${project.artifactId}.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/${project.artifactId}.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v7.0.0</tag>
   </scm>
 
 </project>


### PR DESCRIPTION
Release v7.0.0.

The major version bump is due to several breaking changes made to the /authn/credentials and related endpoints, 

See: https://issues.folio.org/browse/MODLOGIN-126