### PR TITLE
MODLOGIN-129 - back out password requirement: can't be all whitespace

### DIFF
--- a/ramls/login.raml
+++ b/ramls/login.raml
@@ -112,7 +112,7 @@ traits:
               example: "Internal server error"
   /update:
     post:
-      description: Self-update existing credentials.  N.B. A non-empty password must be provided and may not contain only whitespace.
+      description: Self-update existing credentials.  N.B. A non-empty password must be provided.
       headers:
         User-Agent:
         X-Forwarded-For:
@@ -144,7 +144,7 @@ traits:
               example: "Internal server error"
   /credentials:
     post:
-      description: Add a new login to the system. N.B. A non-empty password must be provided and may not contain only whitespace.
+      description: Add a new login to the system. N.B. A non-empty password must be provided.
       is: [validate]
       body:
         application/json:

--- a/src/main/java/org/folio/rest/impl/LoginAPI.java
+++ b/src/main/java/org/folio/rest/impl/LoginAPI.java
@@ -547,7 +547,7 @@ public class LoginAPI implements Authn {
           userVerifyFuture = lookupUser(entity.getUsername(), null,
             tenantId, okapiURL, requestToken);
         }
-        if (entity.getPassword() == null || entity.getPassword().trim().isEmpty()) {
+        if (entity.getPassword() == null || entity.getPassword().isEmpty()) {
           asyncResultHandler.handle(Future.succeededFuture(
             PostAuthnCredentialsResponse.respond422WithApplicationJson(
               ValidationHelper.createValidationErrorMessage(
@@ -1006,7 +1006,7 @@ public class LoginAPI implements Authn {
               .respond400WithTextPlain("You must provide a username or userId")));
           return;
         }
-        if(entity.getNewPassword() == null || entity.getNewPassword().trim().isEmpty()) {
+        if(entity.getNewPassword() == null || entity.getNewPassword().isEmpty()) {
           asyncResultHandler.handle(Future.succeededFuture(PostAuthnLoginResponse
               .respond400WithTextPlain("You must provide a new password that isn't empty")));
           return;

--- a/src/test/java/org/folio/logintest/RestVerticleTest.java
+++ b/src/test/java/org/folio/logintest/RestVerticleTest.java
@@ -110,16 +110,6 @@ public class RestVerticleTest {
       .put("password", "12345")
       .put("newPassword", "");
 
-  private JsonObject newCredsWhitespacePassword = new JsonObject()
-      .put("username", "gollum")
-      .put("password", "12345")
-      .put("newPassword", " \t\r\n");
-
-  private JsonObject credsWhitespacePassword = new JsonObject()
-      .put("username", "saruman")
-      .put("userId", sarumanId)
-      .put("password", " \t\r\n");
-
   private static Vertx vertx;
   private static int port;
   private static int mockPort;
@@ -285,10 +275,8 @@ public class RestVerticleTest {
         .compose(w -> doLogin(context, credsObject1))
         .compose(w -> doLogin(context, credsObject2))
         .compose(w -> postNewCredentialsWithEmptyStringPassword(context, credsEmptyStringPassword))
-        .compose(w -> postNewCredentialsWithEmptyStringPassword(context, credsWhitespacePassword))
         .compose(w -> postNewCredentials(context, credsObject3))
         .compose(w -> doUpdatePasswordWithEmptyString(context, newCredsEmptyPassword))
-        .compose(w -> doUpdatePasswordWithEmptyString(context, newCredsWhitespacePassword))
         .compose(w -> doInactiveLogin(context, credsObject3))
         .compose(w -> doBadPasswordLogin(context, credsObject4))
         .compose(w -> doBadPasswordLogin(context, credsObject5))


### PR DESCRIPTION
## Purpose
Per comments in [MODLOGIN-129](https://issues.folio.org/browse/MODLOGIN-129) made after the [original work](https://github.com/folio-org/mod-login/pull/83) was merged, we want to consolidate password validation into mod-password-validator.

Rules already exist in mod-password-validator work which restrict the use of whitespace.  If needed we can file JIRAs for additional restrictions (e.g. for trailing/leading whitespace)