### PR TITLE
MODLOGIN-135: Upgrade raml-module-builder (RMB) to 30.2.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <ramlfiles_util_path>${basedir}/ramls/raml-util</ramlfiles_util_path>
-    <vertx.version>3.9.1</vertx.version>
+    <vertx.version>3.9.2</vertx.version>
   </properties>
 
   <dependencies>
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>domain-models-runtime</artifactId>
-      <version>30.0.0</version>
+      <version>30.2.6</version>
     </dependency>
 
     <dependency>
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
-      <version>3.0.0</version>
+      <version>4.3.1</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
RMB 30.2.6 release notes: https://github.com/folio-org/raml-module-builder/releases/tag/v30.2.6

 * [RMB-701](https://issues.folio.org/browse/RMB-701) Update to [Vert.x 3.9.2](https://github.com/vert-x3/wiki/wiki/3.9.2-Release-Notes), fixing WebClient request timeout races
 * [RMB-700](https://issues.folio.org/browse/RMB-700) NPE when RestVerticle calls LogUtil.formatStatsLogMessage
 * [RMB-677](https://issues.folio.org/browse/RMB-677) Close PostgreSQL connection after invalid CQL failure