### PR TITLE
MODLOGIN-139: Q2 to Q3 upgrade - "tuple concurrently updated" on REVOKE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>domain-models-runtime</artifactId>
-      <version>31.1.3</version>
+      <version>31.2.0-SNAPSHOT</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
See RMB-744 for details.

Upgrading mod-login from Q2 (Goldenrod) to mod-login-7.1.0 fails with
"tuple concurrently updated" when executing "REVOKE ALL PRIVILEGES
ON SCHEMA public FROM module_schema".

RMB-744 provides a potential fix.

To test this fix we temporarily try RMB-31.2.0-SNAPSHOT on mod-login master.