### PR TITLE
MODLOGIN-140: Upgrade to RMB 31.1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>domain-models-runtime</artifactId>
-      <version>31.2.0-SNAPSHOT</version>
+      <version>31.1.5</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
RMB 31.1.5 provides

* RMB-750 Change lock for "tuple concurrently updated" when upgrading Q2 to Q3 (REVOKE)