### PR TITLE
Fix empty PUT /users/id MODLOGIN-168

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -108,7 +108,7 @@
   "requires" : [
     {
       "id" : "users",
-      "version" : "15.0"
+      "version" : "15.4"
     }
   ],
   "permissionSets" : [

--- a/src/main/java/org/folio/services/impl/PasswordStorageServiceImpl.java
+++ b/src/main/java/org/folio/services/impl/PasswordStorageServiceImpl.java
@@ -12,6 +12,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
+import io.vertx.ext.web.client.predicate.ResponsePredicate;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.cql2pgjson.CQL2PgJSON;
@@ -65,7 +66,7 @@ public class PasswordStorageServiceImpl implements PasswordStorageService {
   private static final String TABLE_NAME_CREDENTIALS_HISTORY = "auth_credentials_history";
   private static final String CREDENTIALS_HISTORY_DATE_FIELD = "date";
   private static final String PW_HISTORY_NUMBER_CONF_PATH =
-    "/configurations/entries?query=configName==password.history.number";//NOSONAR
+    "/configurations/entries?query=configName==password.history.number";
 
   public static final int DEFAULT_PASSWORDS_HISTORY_NUMBER = 10;
 

--- a/src/main/java/org/folio/util/LoginAttemptsHelper.java
+++ b/src/main/java/org/folio/util/LoginAttemptsHelper.java
@@ -34,6 +34,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpRequest;
+import io.vertx.ext.web.client.HttpResponse;
 
 /**
  * Helper class that contains static methods which helps with processing Login Attempts business logic

--- a/src/main/java/org/folio/util/LoginAttemptsHelper.java
+++ b/src/main/java/org/folio/util/LoginAttemptsHelper.java
@@ -11,6 +11,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import io.vertx.core.json.JsonArray;
+import io.vertx.ext.web.client.predicate.ResponsePredicate;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -32,7 +34,6 @@ import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpRequest;
-import io.vertx.ext.web.client.HttpResponse;
 
 /**
  * Helper class that contains static methods which helps with processing Login Attempts business logic
@@ -201,22 +202,20 @@ public class LoginAttemptsHelper {
     HttpRequest<Buffer> request = WebClientFactory.getWebClient(vertx).getAbs(requestURL);
     request.putHeader(OKAPI_TENANT_HEADER, tenant)
       .putHeader(OKAPI_TOKEN_HEADER, requestToken);
-    return request.send().map(res -> {
-      if (res.statusCode() != 200) {
-        String message = "Expected status code 200, got '" + res.statusCode() + "' :" + res.bodyAsString();
-        logger.warn(message);
-        throw new RuntimeException(message);
-      }
+    return request
+      .expect(ResponsePredicate.JSON)
+      .expect(ResponsePredicate.SC_OK)
+      .send().map(res -> {
       JsonObject resultObject = res.bodyAsJsonObject();
-      int recordCount = resultObject.getInteger("totalRecords");
-      if (recordCount > 1) {
+      JsonArray configs = resultObject.getJsonArray("configs");
+      if (configs.size() > 1) {
         throw new RuntimeException("Bad results from configs");
-      } else if (recordCount == 0) {
+      } else if (configs.isEmpty()) {
         String errorMessage = "No config found by code " + configCode;
         logger.error(errorMessage);
         throw new RuntimeException(errorMessage);
       }
-      return resultObject.getJsonArray("configs").getJsonObject(0);
+      return configs.getJsonObject(0);
     });
   }
 
@@ -234,14 +233,9 @@ public class LoginAttemptsHelper {
     HttpRequest<Buffer> request = WebClientFactory.getWebClient(vertx).putAbs(requestURL);
     request.putHeader(OKAPI_TENANT_HEADER, tenant)
       .putHeader(OKAPI_TOKEN_HEADER, requestToken);
-    return request.sendJsonObject(user).map(res -> {
-      if (res.statusCode() != 204) {
-        String body = res.bodyAsString();
-        String message = "Expected status code 204, got '" + res.statusCode() + "' :" + body;
-        throw new RuntimeException(message);
-      }
-      return null;
-    });
+    return request
+      .expect(ResponsePredicate.SC_NO_CONTENT)
+      .sendJsonObject(user).mapEmpty();
   }
 
   /**

--- a/src/test/java/org/folio/logintest/RestVerticleTest.java
+++ b/src/test/java/org/folio/logintest/RestVerticleTest.java
@@ -252,7 +252,7 @@ public class RestVerticleTest {
         .compose(w -> postDuplicateCredentials(context, credsObject1))
         .compose(w -> testMockUser(context, "gollum", null))
         .compose(w -> testMockUser(context, null, gollumId))
-        .compose(w -> failMockUser(context, "yomomma", null))
+        .compose(w -> testMockUser(context, "yomomma", null))
         .compose(w -> doLoginNoToken(context, credsObject1))
         .compose(w -> doLoginNoPassword(context, credsNoPassword))
         .compose(w -> doLoginNoUsernameOrUserId(context, credsNoUsernameOrUserId))
@@ -420,17 +420,6 @@ public class RestVerticleTest {
     }
     return doRequest(vertx, url, HttpMethod.GET, null, null, 200,
       "Test mock /user endpoint at url " + url);
-  }
-
-  private Future<WrappedResponse> failMockUser(TestContext context, String username, String userId) {
-    String url;
-    if (username != null) {
-      url = okapiUrl + "/users?query=username==\"" + username + "\"";
-    } else {
-      url = okapiUrl + "/users?query=id==\"" + userId + "\"";
-    }
-    return doRequest(vertx, url, HttpMethod.GET, null, null, 200,
-      "Fail nonexistent mock /user endpoint at url " + url);
   }
 
   private Future<WrappedResponse> doLogin(TestContext context, JsonObject loginCredentials) {

--- a/src/test/java/org/folio/logintest/RestVerticleTest.java
+++ b/src/test/java/org/folio/logintest/RestVerticleTest.java
@@ -429,7 +429,7 @@ public class RestVerticleTest {
     } else {
       url = okapiUrl + "/users?query=id==\"" + userId + "\"";
     }
-    return doRequest(vertx, url, HttpMethod.GET, null, null, 404,
+    return doRequest(vertx, url, HttpMethod.GET, null, null, 200,
       "Fail nonexistent mock /user endpoint at url " + url);
   }
 

--- a/src/test/java/org/folio/logintest/UserMock.java
+++ b/src/test/java/org/folio/logintest/UserMock.java
@@ -264,17 +264,31 @@ public class UserMock extends AbstractVerticle {
   }
 
   private void handleUserPut(RoutingContext context) {
-    String id = context.request().getParam("id");
-    if(id.equals(adminId)) {
-      admin.put("active", false);
-      context.response()
-        .setStatusCode(204)
-        .end();
-    } else {
-      context.response()
-        .setStatusCode(204)
-        .end();
-    }
+    context.request().body().onSuccess(body -> {
+      try {
+        JsonObject userObject = new JsonObject(body);
+        String id = context.request().getParam("id");
+        if (!userObject.getString("id").equals(id)) {
+          context.response()
+            .setStatusCode(500);
+          return;
+        }
+        if (id.equals(adminId)) {
+          admin.put("active", false);
+          context.response()
+            .setStatusCode(204)
+            .end();
+        } else {
+          context.response()
+            .setStatusCode(204)
+            .end();
+        }
+      } catch (Exception e) {
+        context.response()
+          .setStatusCode(500)
+          .end(e.getMessage());
+      }
+    });
   }
 }
 

--- a/src/test/java/org/folio/logintest/UserMock.java
+++ b/src/test/java/org/folio/logintest/UserMock.java
@@ -76,6 +76,7 @@ public class UserMock extends AbstractVerticle {
             .put("totalRecords", 1);
           context.response()
             .setStatusCode(200)
+            .putHeader("Content-Type", "application/json")
             .end(responseOb.encode());
           break;
         case "username==\"bombadil\"":
@@ -91,22 +92,23 @@ public class UserMock extends AbstractVerticle {
             .put("totalRecords", 1);
           context.response()
             .setStatusCode(200)
+            .putHeader("Content-Type", "application/json")
             .end(responseOb.encode());
           break;
         case "username==\"gimli\"":
           userOb = new JsonObject();
           context.response()
             .setStatusCode(200)
+            .putHeader("Content-Type", "application/json")
             .end(userOb.encode());
           break;
         case "username==\"mrunderhill\"":
-          userOb = new JsonObject();
           responseOb = new JsonObject()
-            .put("users", new JsonArray()
-              .add(userOb))
+            .put("users", new JsonArray())
             .put("totalRecords", 0);
           context.response()
             .setStatusCode(200)
+            .putHeader("Content-Type", "application/json")
             .end(responseOb.encode());
           break;
         case "username==\"gandalf\"":
@@ -123,6 +125,7 @@ public class UserMock extends AbstractVerticle {
             .put("totalRecords", 2);
           context.response()
             .setStatusCode(200)
+            .putHeader("Content-Type", "application/json")
             .end(responseOb.encode());
           break;
         case "username==\"strider\"":
@@ -135,6 +138,7 @@ public class UserMock extends AbstractVerticle {
             .put("totalRecords", 1);
           context.response()
             .setStatusCode(200)
+            .putHeader("Content-Type", "application/json")
             .end(responseOb.encode());
           break;
         case "username==\"saruman\"":
@@ -148,6 +152,7 @@ public class UserMock extends AbstractVerticle {
             .put("totalRecords", 1);
           context.response()
             .setStatusCode(200)
+            .putHeader("Content-Type", "application/json")
             .end(responseOb.encode());
           break;
         case "id==\"" + sarumanId + "\"":
@@ -161,6 +166,7 @@ public class UserMock extends AbstractVerticle {
             .put("totalRecords", 1);
           context.response()
             .setStatusCode(200)
+            .putHeader("Content-Type", "application/json")
             .end(responseOb.encode());
           break;
         case "id==\"" + gollumId + "\"":
@@ -174,22 +180,29 @@ public class UserMock extends AbstractVerticle {
             .put("totalRecords", 1);
           context.response()
             .setStatusCode(200)
+            .putHeader("Content-Type", "application/json")
             .end(responseOb.encode());
           break;
         case "username==\"admin\"":
           context.response()
             .setStatusCode(200)
+            .putHeader("Content-Type", "application/json")
             .end(responseAdmin.encode());
           break;
         case "id==\"" + adminId + "\"":
           context.response()
             .setStatusCode(200)
+            .putHeader("Content-Type", "application/json")
             .end(responseAdmin.encode());
           break;
         default:
+          responseOb = new JsonObject()
+            .put("users", new JsonArray())
+            .put("totalRecords", 0);
           context.response()
-            .setStatusCode(404)
-            .end("Not found. Query: " + query);
+            .setStatusCode(200)
+            .putHeader("Content-Type", "application/json")
+            .end(responseOb.encode());
           break;
       }
     } catch (Exception e) {
@@ -202,6 +215,7 @@ public class UserMock extends AbstractVerticle {
   private void handleToken(RoutingContext context) {
     context.response()
       .setStatusCode(201)
+      .putHeader("Content-Type", "application/json")
       .putHeader("X-Okapi-Token", "dummytoken")
       .end(new JsonObject().put("token", "dummytoken").encode());
   }
@@ -209,6 +223,7 @@ public class UserMock extends AbstractVerticle {
   private void handleRefreshToken(RoutingContext context) {
     context.response()
       .setStatusCode(201)
+      .putHeader("Content-Type", "application/json")
       .end(new JsonObject().put("refreshToken", "dummyrefreshtoken").encode());
   }
 
@@ -250,6 +265,7 @@ public class UserMock extends AbstractVerticle {
       if(responseJson != null) {
         context.response()
           .setStatusCode(200)
+          .putHeader("Content-Type", "application/json")
           .end(responseJson.encode());
       } else {
         context.response()
@@ -276,14 +292,11 @@ public class UserMock extends AbstractVerticle {
         }
         if (id.equals(adminId)) {
           admin.put("active", false);
-          context.response()
-            .setStatusCode(204)
-            .end();
-        } else {
-          context.response()
-            .setStatusCode(204)
-            .end();
         }
+        context.response()
+          .setStatusCode(204)
+          .putHeader("Content-Type", "application/json")
+          .end();
       } catch (Exception e) {
         context.response()
           .setStatusCode(500)

--- a/src/test/java/org/folio/logintest/UserMock.java
+++ b/src/test/java/org/folio/logintest/UserMock.java
@@ -270,7 +270,8 @@ public class UserMock extends AbstractVerticle {
         String id = context.request().getParam("id");
         if (!userObject.getString("id").equals(id)) {
           context.response()
-            .setStatusCode(500);
+            .setStatusCode(500)
+            .end("user.id != param.id");
           return;
         }
         if (id.equals(adminId)) {

--- a/src/test/java/org/folio/logintest/UserMock.java
+++ b/src/test/java/org/folio/logintest/UserMock.java
@@ -253,25 +253,23 @@ public class UserMock extends AbstractVerticle {
 
   private void handleConfig(RoutingContext context) {
     try {
-      JsonObject responseJson = null;
+      JsonObject responseJson;
       String queryString = "code==";
       String query = context.request().getParam("query");
       if (query.equals(queryString + LOGIN_ATTEMPTS_CODE)) {
         responseJson = configs.get(LOGIN_ATTEMPTS_CODE);
       } else if (query.equals(queryString + LOGIN_ATTEMPTS_TIMEOUT_CODE)) {
         responseJson = configs.get(LOGIN_ATTEMPTS_TIMEOUT_CODE);
-      }
-
-      if(responseJson != null) {
-        context.response()
-          .setStatusCode(200)
-          .putHeader("Content-Type", "application/json")
-          .end(responseJson.encode());
       } else {
-        context.response()
-          .setStatusCode(404)
-          .end("Not found");
+        responseJson = new JsonObject()
+          .put("configs", new JsonArray())
+          .put("totalRecords", 0);
       }
+      System.out.println("AD: returning " + responseJson.encodePrettily());
+      context.response()
+        .setStatusCode(200)
+        .putHeader("Content-Type", "application/json")
+        .end(responseJson.encode());
     } catch (Exception e) {
       context.response()
         .setStatusCode(500)


### PR DESCRIPTION
https://issues.folio.org/browse/MODLOGIN-168

The user object is not sent in https://github.com/folio-org/mod-login/blob/v7.5.0/src/main/java/org/folio/util/LoginAttemptsHelper.java#L265

On top of the bug fix, simplify WebClient usage:
Change promise to map in WebClient calls.
sendJsonObject automatically sends content type application/json
And content-type is not necessary for GETs (send()).
Since RMB 32.2.0, Accept is no longer necessary in most cases.

