### PR TITLE
Optional dependency on authtoken 2.0 MODLOGIN-155

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -115,6 +115,10 @@
     {
       "id" : "configuration",
       "version" : "2.0"
+    },
+    {
+      "id" : "authtoken",
+      "version" : "2.0"
     }
   ],
   "permissionSets" : [


### PR DESCRIPTION
Requiring it is optional as in boostrap process you need
to specify credentials for admin user - before mod-authtoken
is enabled (and interface authtoken).