### PR TITLE
Fix CQL query encoded incorrectly MODLOGIN-184

### DIFF
--- a/src/main/java/org/folio/util/LoginAttemptsHelper.java
+++ b/src/main/java/org/folio/util/LoginAttemptsHelper.java
@@ -196,7 +196,7 @@ public class LoginAttemptsHelper {
     String requestToken = okapiHeaders.get(XOkapiHeaders.TOKEN);
     String okapiUrl = okapiHeaders.get(XOkapiHeaders.URL);
 
-    requestURL = okapiUrl + "/configurations/entries?query=" + "code==" + StringUtil.urlEncode(configCode);
+    requestURL = okapiUrl + "/configurations/entries?query=" + PercentCodec.encode("code==" + configCode);
     HttpRequest<Buffer> request = WebClientFactory.getWebClient(vertx).getAbs(requestURL);
     request.putHeader(XOkapiHeaders.TENANT, tenant)
       .putHeader(XOkapiHeaders.TOKEN, requestToken);


### PR DESCRIPTION
https://issues.folio.org/browse/MODLOGIN-184

Don't think it's necessary to CQL encode the `code` term itself as the code is usually only dots and alphanumerics.