### PR TITLE
Document config entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ default implementation uses a simple username and password for authentication.
 
 # Module properties
 
-The following module parameters can be specified on the command line.  
+The following module parameters can be specified on the command line.
 See https://github.com/folio-org/raml-module-builder#command-line-options
 When specified, these will take precedence over the hard-coded defaults.
 
@@ -26,7 +26,7 @@ When specified, these will take precedence over the hard-coded defaults.
 # Mod-configuration entries
 
 The following configuration entries can be specified in mod-configuration.
-When present, these will take precedence over the 
+When present, these will take precedence over the
 hard-coded defaults and the module parameter values specified on the command line.
 
 | Module    | Code                    | configName                  | Description                                                                        |

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ default implementation uses a simple username and password for authentication.
 # Module properties
 
 The following module parameters can be specified on the command line.
-See https://github.com/folio-org/raml-module-builder#command-line-options
+See <https://github.com/folio-org/raml-module-builder#command-line-options>
 When specified, these will take precedence over the hard-coded defaults.
 
 * login.fail.to.warn.attempts - number of login attempts before warn (default value - 3)

--- a/README.md
+++ b/README.md
@@ -13,11 +13,34 @@ this module may vary (username/password, SAML, OAuth, etc.), and it is possible
 for more than one Authentication module to exist in a running system. The
 default implementation uses a simple username and password for authentication.
 
-# Module properties to set up at mod-configuration
+# Module properties
+
+The following module parameters can be specified on the command line.  
+See https://github.com/folio-org/raml-module-builder#command-line-options
+When specified, these will take precedence over the hard-coded defaults.
 
 * login.fail.to.warn.attempts - number of login attempts before warn (default value - 3)
 * login.fail.attempts - number of login attempts before block user account (default value - 5)
 * login.fail.timeout - after timeout in minutes, fail login attempts will be dropped (default value - 10)
+
+# Mod-configuration entries
+
+The following configuration entries can be specified in mod-configuration.
+When present, these will take precedence over the 
+hard-coded defaults and the module parameter values specified on the command line.
+
+| Module    | Code                    | configName                  | Description                                                                        |
+|:----------|:------------------------|:----------------------------|:-----------------------------------------------------------------------------------|
+| EVENT_LOG | STATUS                  | {any}                       | Enable/disable event logging.  If disabled, events will not be logged, nor will you be able to retreive previously logged entries (default: enabled=false) |
+| EVENT_LOG | SUCESSFUL_LOGIN_ATTEMPT | {any}                       | If enabled, log successful login attempts to the event log (default: enabled=false) |
+| EVENT_LOG | FAILED_LOGIN_ATTEMPT    | {any}                       | If enabled, log failed login attempts to the event log (default: enabled=false)     |
+| EVENT_LOG | PASSWORD_RESET          | {any}                       | If enabled, log password reset events to the event log (default: enabled=false)     |
+| EVENT_LOG | PASSWORD_CREATE         | {any}                       | If enabled, log password creation events to the event log (default: enabled=false)  |
+| EVENT_LOG | PASSWORD_CHANGE         | {any}                       | If enabled, log password change events to the event log (default: enabled=false)    |
+| EVENT_LOG | USER_BLOCK              | {any}                       | If enabled, log user blocked events to the event log (default: enabled=false)       |
+| {any}     | {any}                   | login.fail.attempts         | Number of login attempts before block user account (default: value=5)               |
+| {any}     | {any}                   | login.fail.to.warn.attempts | Number of login attempts before warn (default: value=3)                             |
+| {any}     | {any}                   | login.fail.timeout          | after timeout in minutes, fail login attempts will be dropped (default: value=10)   |
 
 # Additional information
 


### PR DESCRIPTION
## Purpose
The configuration entries used by this module are not (as far as I can tell) documented anywhere.  

## Approach
Update the README:
* Add a table with the various configuration entries used by this module, including:
  * Which fields of the configuration entry are used to identify them (module, code, configName, etc.)
  * Default values
  * Description of each
* Add clarifying remarks to the section about "Module properties".