### PR TITLE
MODLOGIN-218: Update dependencies for Poppy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,13 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>2.20.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
 
       <dependency>
         <groupId>io.vertx</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,8 @@
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <ramlfiles_util_path>${basedir}/ramls/raml-util</ramlfiles_util_path>
     <aspectj.version>1.9.19</aspectj.version>
-    <vertx.version>4.3.8</vertx.version>
-    <raml-module-builder-version>35.0.6</raml-module-builder-version>
+    <vertx.version>4.4.5</vertx.version>
+    <raml-module-builder-version>35.1.0</raml-module-builder-version>
   </properties>
 
   <dependencyManagement>
@@ -114,7 +114,7 @@
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
-      <version>5.2.0</version>
+      <version>5.3.2</version>
       <scope>test</scope>
     </dependency>
 
@@ -128,7 +128,7 @@
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
       <artifactId>wiremock</artifactId>
-      <version>2.27.2</version>
+      <version>3.0.1</version>
       <scope>test</scope>
     </dependency>
 
@@ -156,7 +156,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.4.0</version>
         <executions>
           <execution>
             <id>add_generated_sources_folder</id>
@@ -191,7 +191,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.11.0</version>
         <configuration>
           <release>17</release>
           <encoding>UTF-8</encoding>
@@ -220,7 +220,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.1</version>
+        <version>3.1.2</version>
         <configuration>
           <useSystemClassLoader>false</useSystemClassLoader>
         </configuration>
@@ -230,7 +230,7 @@
 
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-        <version>1.5.0</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>git submodule update</id>
@@ -295,7 +295,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.0.1</version>
+        <version>3.3.1</version>
         <executions>
           <execution>
             <id>copy-resources</id>
@@ -399,7 +399,7 @@
         apidocs directory so that they can be used via the local html api console. -->
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
-        <version>1.8</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <phase>prepare-package</phase>
@@ -426,8 +426,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.2.4</version>
+        <version>3.5.1</version>
         <configuration>
+          <createDependencyReducedPom>false</createDependencyReducedPom>
           <filters>
             <filter>
               <artifact>*:*</artifact>
@@ -463,7 +464,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
-        <version>2.5.3</version>
+        <version>3.0.1</version>
         <configuration>
           <preparationGoals>clean verify</preparationGoals>
           <tagNameFormat>v@{project.version}</tagNameFormat>


### PR DESCRIPTION
Adding the reference in the pom to log4j before vertx seems to be needed for the container to start. It will build without it, but [failed when the docker image started for the health check](https://jenkins-aws.indexdata.com/blue/organizations/jenkins/folio-org%2Fmod-login/detail/MODLOGIN-218/1/pipeline). 