### PR TITLE
getValue() causes "java.lang.ClassCastException"

### DIFF
--- a/src/main/java/org/folio/util/LoginAttemptsHelper.java
+++ b/src/main/java/org/folio/util/LoginAttemptsHelper.java
@@ -166,7 +166,7 @@ public class LoginAttemptsHelper {
     if (res.failed()) {
       logger.warn(res.cause());
     } else try {
-      return res.result().getInteger(VALUE, defaultValue);
+      return Integer.parseInt(res.result().getValue(VALUE, defaultValue).toString());
     } catch (Exception e) {
       logger.error(e);
     }


### PR DESCRIPTION
according to the [kv_configuration.schema](https://github.com/folio-org/mod-configuration/blob/master/ramls/_schemas/kv_configuration.schema),the type of value is STRING,so the function here will always throw  **java.lang.ClassCastException:class java.lang.String cannot be cast to class java.lang.Number**