### PR TITLE
MODLOGIN-227: Upgrade to Vert.x 4.5.7 and RMB 35.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,8 @@
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <ramlfiles_util_path>${basedir}/ramls/raml-util</ramlfiles_util_path>
     <aspectj.version>1.9.19</aspectj.version>
-    <vertx.version>4.5.4</vertx.version>
-    <raml-module-builder-version>35.2.0</raml-module-builder-version>
+    <vertx.version>4.5.7</vertx.version>
+    <raml-module-builder-version>35.2.2</raml-module-builder-version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
The Vert.x upgrade indirectly upgrades Netty from 4.1.107.Final to 4.1.108.Final fixing https://nvd.nist.gov/vuln/detail/CVE-2024-29025
Allocation of Resources Without Limits or Throttling