### PR TITLE
Cookie maxAge off by 1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,13 @@
       <scope>test</scope>
     </dependency>
 
+    <!-- testcontainers use slf4j loggin -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.wiremock</groupId>
       <artifactId>wiremock</artifactId>
@@ -156,6 +163,7 @@
       <version>4.2.2</version>
       <scope>test</scope>
     </dependency>
+
   </dependencies>
 
   <build>

--- a/src/test/java/org/folio/logintest/LoginWithExpiryTest.java
+++ b/src/test/java/org/folio/logintest/LoginWithExpiryTest.java
@@ -3,6 +3,7 @@ package org.folio.logintest;
 import static org.folio.logintest.Mocks.*;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.oneOf;
 import static org.hamcrest.Matchers.nullValue;
 
 import org.folio.rest.impl.LoginAPI;
@@ -109,7 +110,7 @@ public class LoginWithExpiryTest {
   }
 
   @Test
-  public void testLoginWithExpiry(final TestContext context) {
+  public void testLoginWithExpiry() {
     RestAssured.given()
         .spec(spec)
         .body(credsObject1.encode())
@@ -322,7 +323,7 @@ public class LoginWithExpiryTest {
         .contentType("application/json")
         .cookie(LoginAPI.FOLIO_REFRESH_TOKEN, RestAssuredMatchers.detailedCookie()
             .value(Mocks.REFRESH_TOKEN)
-            .maxAge(Mocks.REFRESH_TOKEN_EXPIRATION)
+            .maxAge(is(oneOf(Mocks.REFRESH_TOKEN_EXPIRATION - 1L, (long) Mocks.REFRESH_TOKEN_EXPIRATION)))
             .path("/authn") // Refresh is restricted to this domain.
             .httpOnly(true)
             .secured(true)
@@ -330,7 +331,7 @@ public class LoginWithExpiryTest {
             .sameSite(sameSite))
         .cookie(LoginAPI.FOLIO_ACCESS_TOKEN, RestAssuredMatchers.detailedCookie()
             .value(Mocks.ACCESS_TOKEN)
-            .maxAge(Mocks.ACCESS_TOKEN_EXPIRATION)
+            .maxAge(is(oneOf(Mocks.ACCESS_TOKEN_EXPIRATION - 1L, (long) Mocks.ACCESS_TOKEN_EXPIRATION)))
             .path("/") // Path must be set in this way for it to mean "all paths".
             .httpOnly(true)
             .secured(true)

--- a/src/test/java/org/folio/logintest/RefreshTest.java
+++ b/src/test/java/org/folio/logintest/RefreshTest.java
@@ -6,6 +6,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.any;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.oneOf;
 
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
 import org.folio.okapi.common.XOkapiHeaders;
@@ -123,12 +124,12 @@ public class RefreshTest {
   }
 
   @Test
-  public void testRefreshCreated(final TestContext context) {
+  public void testRefreshCreated() {
     validateSpecWithCookieResponse(specWithBothAccessAndRefreshTokenCookie);
   }
 
   @Test
-  public void testOkMissingAccessTokenCookie(final TestContext context) {
+  public void testOkMissingAccessTokenCookie() {
     validateSpecWithCookieResponse(specWithoutAccessTokenCookie);
   }
 
@@ -143,7 +144,7 @@ public class RefreshTest {
         .contentType("application/json")
         .cookie(LoginAPI.FOLIO_REFRESH_TOKEN, RestAssuredMatchers.detailedCookie()
             .value(Mocks.REFRESH_TOKEN)
-            .maxAge(Mocks.REFRESH_TOKEN_EXPIRATION)
+            .maxAge(is(oneOf(Mocks.REFRESH_TOKEN_EXPIRATION - 1L, (long) Mocks.REFRESH_TOKEN_EXPIRATION)))
             .path("/authn")
             .httpOnly(true)
             .sameSite("Lax")
@@ -151,7 +152,7 @@ public class RefreshTest {
             .secured(true))
         .cookie(LoginAPI.FOLIO_ACCESS_TOKEN, RestAssuredMatchers.detailedCookie()
             .value(Mocks.ACCESS_TOKEN)
-            .maxAge(Mocks.ACCESS_TOKEN_EXPIRATION)
+            .maxAge(is(oneOf(Mocks.ACCESS_TOKEN_EXPIRATION - 1L, (long) Mocks.ACCESS_TOKEN_EXPIRATION)))
             .httpOnly(true)
             .sameSite("Lax")
             .path("/") // Access token path is '/'. It is sent on every request.
@@ -178,7 +179,7 @@ public class RefreshTest {
   }
 
   @Test
-  public void testRefreshBadRequestEmptyCookie(final TestContext context) {
+  public void testRefreshBadRequestEmptyCookie() {
     RestAssured.given()
         .spec(specBadRequestEmptyCookie)
         .when()
@@ -191,7 +192,7 @@ public class RefreshTest {
   }
 
   @Test
-  public void testRefreshBadRequestNoCookie(final TestContext context) {
+  public void testRefreshBadRequestNoCookie() {
     RestAssured.given()
         .spec(specBadRequestNoCookie)
         .when()
@@ -204,7 +205,7 @@ public class RefreshTest {
   }
 
   @Test
-  public void testDuplicateKeyCookie(final TestContext context) {
+  public void testDuplicateKeyCookie() {
     RestAssured.given()
         .spec(specDuplicateKeyCookie)
         .when()


### PR DESCRIPTION
Cookie's maxAge gets calculated using refreshTokenExpiration minus current time. This may result in this test failure:

```
[ERROR]   LoginWithExpiryTest.testLoginWithExpiry:221->testCookieResponse:323 1 expectation failed.
Expected cookie "folioRefreshToken" was not (… hasProperty("maxAge", <604800L>)  property 'maxAge' was <604799L>.
```

Solution: Change the tests to also accept the expected value minus one.