### PR TITLE
MODLOGIN-215: Remove all code associated with /authn/login endpoint

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -34,19 +34,6 @@
         },
         {
           "methods" : [ "POST" ],
-          "pathPattern" : "/authn/login",
-          "permissionsRequired" : [ ],
-          "modulePermissions" : [
-            "auth.sign-and-refresh-token.all",
-            "users.collection.get",
-            "users.item.put",
-            "users.item.get",
-            "configuration.entries.collection.get",
-            "user-tenants.collection.get"
-          ]
-        },
-        {
-          "methods" : [ "POST" ],
           "pathPattern" : "/authn/login-with-expiry",
           "permissionsRequired" : [ ],
           "modulePermissions" : [
@@ -153,10 +140,6 @@
     {
       "id" : "configuration",
       "version" : "2.0"
-    },
-    {
-      "id" : "authtoken",
-      "version" : "2.1"
     },
     {
       "id" : "authtoken2",

--- a/ramls/login.raml
+++ b/ramls/login.raml
@@ -81,42 +81,6 @@ traits:
             body:
               text/plain:
                 example: "Internal server error"
-  /login:
-    post:
-      description: Deprecated. Please use login-with-expiry instead. Will be removed in a future release. Get a new login token without an expiration (legacy endpoint)
-      headers:
-        User-Agent:
-        X-Forwarded-For:
-      body:
-        application/json:
-          type: loginCredentials
-      responses:
-        201:
-          headers:
-            x-okapi-token:
-          body:
-            application/json:
-              type: loginResponse
-        400:
-          description: "Bad request"
-          body:
-            text/plain:
-              example: "Bad request"
-        404:
-          description: "Not found"
-          body:
-            text/plain:
-              example: "Not found"
-        422:
-          description: "Unprocessable Entity"
-          body:
-            application/json:
-              type: errors
-        500:
-          description: "Internal server error"
-          body:
-            text/plain:
-              example: "Internal server error"
   /login-with-expiry:
     post:
       description: Get an expiring refresh and access token

--- a/src/test/java/org/folio/logintest/CrossTenantLoginTest.java
+++ b/src/test/java/org/folio/logintest/CrossTenantLoginTest.java
@@ -39,7 +39,7 @@ public class CrossTenantLoginTest {
   private static final String TENANT_DIKU = "diku";
   private static final String TENANT_OTHER = "other";
   private static final String CRED_PATH = "/authn/credentials";
-  private static final String LOGIN_PATH = "/authn/login";
+  private static final String LOGIN_PATH = "/authn/login-with-expiry";
   private static final String adminId = "8bd684c1-bbc3-4cf1-bcf4-8013d02a94ce";
 
   final private JsonObject credsWithTenant1 = new JsonObject()

--- a/src/test/java/org/folio/logintest/EventsLoggingTests.java
+++ b/src/test/java/org/folio/logintest/EventsLoggingTests.java
@@ -126,7 +126,7 @@ public class EventsLoggingTests {
       .spec(spec)
       .body(JsonObject.mapFrom(body).encode())
       .when()
-      .post("/authn/login")
+      .post("/authn/login-with-expiry")
       .then()
       .statusCode(201);
 
@@ -147,7 +147,7 @@ public class EventsLoggingTests {
       .spec(spec)
       .body(JsonObject.mapFrom(body).encode())
       .when()
-      .post("/authn/login")
+      .post("/authn/login-with-expiry")
       .then()
       .statusCode(422);
 
@@ -170,7 +170,7 @@ public class EventsLoggingTests {
         .spec(spec)
         .body(JsonObject.mapFrom(body).encode())
         .when()
-        .post("/authn/login")
+        .post("/authn/login-with-expiry")
         .then()
         .statusCode(422));
 
@@ -347,8 +347,12 @@ public class EventsLoggingTests {
     );
 
     mockServer.stubFor(
-      WireMock.post("/token")
-        .willReturn(WireMock.okJson(new JsonObject().put("token", "dummytoken").encode())
+      WireMock.post("/token/sign")
+        .willReturn(WireMock.okJson(new JsonObject()
+                .put("accessTokenExpiration", Instant.now().plusSeconds(600).toString())
+                .put("refreshTokenExpiration", Instant.now().plusSeconds(604800).toString())
+                .put("accessToken", "folio-access-token")
+                .put("refreshToken", "folio-refresh-token").encode())
         .withStatus(201))
     );
   }

--- a/src/test/java/org/folio/logintest/LoginAttemptsTest.java
+++ b/src/test/java/org/folio/logintest/LoginAttemptsTest.java
@@ -14,6 +14,7 @@ import java.util.UUID;
 import org.folio.okapi.common.XOkapiHeaders;
 import org.folio.postgres.testing.PostgresTesterContainer;
 import org.folio.rest.RestVerticle;
+import org.folio.rest.impl.LoginAPI;
 import org.folio.rest.jaxrs.model.Password;
 import org.folio.rest.jaxrs.model.TenantAttributes;
 import org.folio.rest.persist.PostgresClient;
@@ -44,7 +45,7 @@ public class LoginAttemptsTest {
   private static final String TENANT_DIKU = "diku";
   private static final String CRED_PATH = "/authn/credentials";
   private static final String ATTEMPTS_PATH = "/authn/loginAttempts";
-  private static final String LOGIN_PATH = "/authn/login";
+  private static final String LOGIN_PATH = "/authn/login-with-expiry";
   private static final String UPDATE_PATH = "/authn/update";
   private static final String adminId = "8bd684c1-bbc3-4cf1-bcf4-8013d02a94ce";
 
@@ -177,8 +178,8 @@ public class LoginAttemptsTest {
       .then()
       .log().all()
       .statusCode(201)
-      .body("okapiToken", is("dummytoken"))
-      .header(XOkapiHeaders.TOKEN, is("dummytoken"));
+      .cookie(LoginAPI.FOLIO_REFRESH_TOKEN)
+      .cookie(LoginAPI.FOLIO_ACCESS_TOKEN);
 
     RestAssured.given()
       .spec(spec)

--- a/src/test/java/org/folio/logintest/LoginWithExpiryTest.java
+++ b/src/test/java/org/folio/logintest/LoginWithExpiryTest.java
@@ -299,16 +299,6 @@ public class LoginWithExpiryTest {
         .then()
         .log().all()
         .statusCode(404);
-
-    System.setProperty(Mocks.TOKEN_FETCH_ERROR_STATUS, "500");
-    RestAssured.given()
-        .spec(spec)
-        .body(credsObject4.encode())
-        .when()
-        .post("/authn/login")
-        .then()
-        .log().all()
-        .statusCode(500);
   }
 
   private void testCookieResponse(JsonObject creds, String sameSite) {

--- a/src/test/java/org/folio/logintest/Mocks.java
+++ b/src/test/java/org/folio/logintest/Mocks.java
@@ -75,7 +75,6 @@ public class Mocks extends AbstractVerticle {
   public static final int REFRESH_TOKEN_EXPIRATION = 604800;
   public static final int ACCESS_TOKEN_EXPIRATION = 600;
   public static final String TOKEN_FETCH_ERROR_STATUS = "tokenShouldReturn404";
-  public static final String TOKEN_FETCH_SHOULD_RETURN_500 = "tokenShouldReturn500";
 
   private static final String adminId = "8bd684c1-bbc3-4cf1-bcf4-8013d02a94ce";
   private static final String userWithSingleTenantId = "08b9e1c4-a0b2-4c64-8d57-2e18784ac7fe";
@@ -292,10 +291,10 @@ public class Mocks extends AbstractVerticle {
     var atExpiration = Instant.now().plusSeconds(ACCESS_TOKEN_EXPIRATION).toString();
     var rtExpiration = Instant.now().plusSeconds(REFRESH_TOKEN_EXPIRATION).toString();
     var response = new JsonObject()
-      .put("accessTokenExpiration", atExpiration)
-      .put("refreshTokenExpiration", rtExpiration)
-      .put("accessToken", ACCESS_TOKEN)
-      .put("refreshToken", REFRESH_TOKEN);
+        .put("accessTokenExpiration", atExpiration)
+        .put("refreshTokenExpiration", rtExpiration)
+        .put("accessToken", ACCESS_TOKEN)
+        .put("refreshToken", REFRESH_TOKEN);
     context.response()
       .setStatusCode(201)
       .putHeader("Content-Type", "application/json")

--- a/src/test/java/org/folio/logintest/RestVerticleTest.java
+++ b/src/test/java/org/folio/logintest/RestVerticleTest.java
@@ -85,7 +85,7 @@ public class RestVerticleTest {
     mockPort = NetworkUtils.nextFreePort(); //get another
     vertx = Vertx.vertx();
     credentialsUrl = "http://localhost:" + port + "/authn/credentials";
-    loginUrl = "http://localhost:" + port + "/authn/login";
+    loginUrl = "http://localhost:" + port + "/authn/login-with-expiry";
     updateUrl = "http://localhost:" + port + "/authn/update";
     okapiUrl = "http://localhost:" + mockPort;
 


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODLOGIN-215. Also resolves https://folio-org.atlassian.net/browse/MODLOGIN-215

* Remove legacy route
* Replace `PostAuthnLoginResponse` with `PostAuthnLoginWithExpiryResponse` throughout. This may have been an oversight that it wasn't done earlier.
* Remove route from module descriptor.
* Change tests that used `/authn/login` to use `/authn/login-with-expiry`.